### PR TITLE
Generate fixtures from a database

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,80 @@
+package testfixtures
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Save generates fixtures for the current contents of a database, and saves
+// them to the specified directory
+func GenerateFixtures(db *sql.DB, helper Helper, dir string) error {
+	tables, err := helper.tableNames(db)
+	if err != nil {
+		return err
+	}
+	for _, table := range tables {
+		filename := path.Join(dir, table+".yml")
+		if err := generateFixturesForTable(db, table, filename); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generateFixturesForTable(db *sql.DB, table string, filename string) error {
+	query := fmt.Sprintf("SELECT * FROM %s;", table)
+	rows, err := db.Query(query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+
+	fixtures := make([]interface{}, 0, 10)
+	for rows.Next() {
+		entries := make([]interface{}, len(columns))
+		entryPtrs := make([]interface{}, len(entries))
+		for i := range entries {
+			entryPtrs[i] = &entries[i]
+		}
+		if err := rows.Scan(entryPtrs...); err != nil {
+			return err
+		}
+
+		entryMap := make(map[string]interface{}, len(entries))
+		for i, column := range columns {
+			entryMap[column] = convertValue(entries[i])
+		}
+		fixtures = append(fixtures, entryMap)
+	}
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	marshaled, err := yaml.Marshal(fixtures)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(marshaled)
+	return err
+}
+
+func convertValue(value interface{}) interface{} {
+	switch value.(type) {
+	case []byte:
+		return string(value.([]byte))
+	default:
+		return value
+	}
+}

--- a/helper.go
+++ b/helper.go
@@ -19,6 +19,7 @@ type Helper interface {
 	disableReferentialIntegrity(*sql.DB, loadFunction) error
 	paramType() int
 	databaseName(*sql.DB) string
+	tableNames(*sql.DB) ([]string, error)
 	quoteKeyword(string) string
 	whileInsertOnTable(*sql.Tx, string, func() error) error
 }

--- a/mysql.go
+++ b/mysql.go
@@ -23,6 +23,30 @@ func (*MySQL) databaseName(db *sql.DB) (dbName string) {
 	return
 }
 
+func (h *MySQL) tableNames(db *sql.DB) ([]string, error) {
+	query := `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_schema=?;
+	`
+	rows, err := db.Query(query, h.databaseName(db))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err = rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+	return tables, nil
+
+}
+
 func (h *MySQL) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) error {
 	// re-enable after load
 	defer db.Exec("SET FOREIGN_KEY_CHECKS = 1")

--- a/oracle.go
+++ b/oracle.go
@@ -48,6 +48,29 @@ func (*Oracle) databaseName(db *sql.DB) (dbName string) {
 	return
 }
 
+func (*Oracle) tableNames(db *sql.DB) ([]string, error) {
+	query := `
+		SELECT table_name
+		FROM all_tables
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err = rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+	return tables, nil
+
+}
+
 func (*Oracle) getEnabledConstraints(db *sql.DB) ([]oracleConstraint, error) {
 	var constraints []oracleConstraint
 	rows, err := db.Query(`

--- a/postgresql.go
+++ b/postgresql.go
@@ -28,7 +28,7 @@ type pgConstraint struct {
 func (h *PostgreSQL) init(db *sql.DB) error {
 	var err error
 
-	h.tables, err = h.getTables(db)
+	h.tables, err = h.tableNames(db)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (*PostgreSQL) databaseName(db *sql.DB) (dbName string) {
 	return
 }
 
-func (h *PostgreSQL) getTables(db *sql.DB) ([]string, error) {
+func (h *PostgreSQL) tableNames(db *sql.DB) ([]string, error) {
 	var tables []string
 
 	sql := `

--- a/sqlite.go
+++ b/sqlite.go
@@ -22,6 +22,29 @@ func (*SQLite) databaseName(db *sql.DB) (dbName string) {
 	return
 }
 
+func (*SQLite) tableNames(db *sql.DB) ([]string, error) {
+	query := `
+		SELECT name
+		FROM sqlite_master
+		WHERE type='table';
+	`
+	rows, err := db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err = rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+	return tables, nil
+}
+
 func (*SQLite) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) error {
 	tx, err := db.Begin()
 	if err != nil {

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -16,7 +16,7 @@ type SQLServer struct {
 func (h *SQLServer) init(db *sql.DB) error {
 	var err error
 
-	h.tables, err = h.getTables(db)
+	h.tables, err = h.tableNames(db)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (*SQLServer) databaseName(db *sql.DB) (dbname string) {
 	return
 }
 
-func (*SQLServer) getTables(db *sql.DB) ([]string, error) {
+func (*SQLServer) tableNames(db *sql.DB) ([]string, error) {
 	rows, err := db.Query("SELECT table_name FROM information_schema.tables")
 	if err != nil {
 		return nil, err

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -90,6 +90,22 @@ func TestLoadFixtures(t *testing.T) {
 			testLocalJSONColumnFixtures(t, db, database.helper)
 		}
 
+		// generate fixtures from database
+		dir, err := ioutil.TempDir(os.TempDir(), "testfixtures_test")
+		if err != nil {
+			t.Error(err)
+		}
+		if err := GenerateFixtures(db, database.helper, dir); err != nil {
+			t.Error(err)
+		}
+
+		// should be able to load generated fixtures
+		context, err := NewFolder(db, database.helper, dir)
+		if err != nil {
+			t.Error(err)
+		} else if err := context.Load(); err != nil {
+			t.Error(err)
+		}
 	}
 }
 


### PR DESCRIPTION
- Add a `GenerateFixtures(db, helper, dir)` function to generate fixtures from a database.
- Update the `Helper` interface to include a `tableNames(db) ([]string, error)` method
- Add tests for this new functionality (tests have been run and passed on SQLite, MySQL, and PostgreSQL)