### PR TITLE
Checksum optimization for MySQL

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -20,7 +20,7 @@ type Helper interface {
 	paramType() int
 	databaseName(*sql.DB) string
 	tableNames(*sql.DB) ([]string, error)
-	tableModified(*sql.DB, string) (bool, error)
+	isTableModified(*sql.DB, string) (bool, error)
 	tablesLoaded(*sql.DB) error
 	quoteKeyword(string) string
 	whileInsertOnTable(*sql.Tx, string, func() error) error
@@ -40,7 +40,7 @@ func (*baseHelper) whileInsertOnTable(_ *sql.Tx, _ string, fn func() error) erro
 	return fn()
 }
 
-func (*baseHelper) tableModified(_ *sql.DB, _ string) (bool, error) {
+func (*baseHelper) isTableModified(_ *sql.DB, _ string) (bool, error) {
 	return true, nil
 }
 

--- a/helper.go
+++ b/helper.go
@@ -20,6 +20,8 @@ type Helper interface {
 	paramType() int
 	databaseName(*sql.DB) string
 	tableNames(*sql.DB) ([]string, error)
+	tableModified(*sql.DB, string) (bool, error)
+	tablesLoaded(*sql.DB) error
 	quoteKeyword(string) string
 	whileInsertOnTable(*sql.Tx, string, func() error) error
 }
@@ -36,4 +38,12 @@ func (*baseHelper) quoteKeyword(str string) string {
 
 func (*baseHelper) whileInsertOnTable(_ *sql.Tx, _ string, fn func() error) error {
 	return fn()
+}
+
+func (*baseHelper) tableModified(_ *sql.DB, _ string) (bool, error) {
+	return true, nil
+}
+
+func (*baseHelper) tablesLoaded(_ *sql.DB) error {
+	return nil
 }

--- a/mysql.go
+++ b/mysql.go
@@ -76,7 +76,7 @@ func (h *MySQL) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) (er
 	return tx.Commit()
 }
 
-func (h *MySQL) tableModified(db *sql.DB, tableName string) (bool, error) {
+func (h *MySQL) isTableModified(db *sql.DB, tableName string) (bool, error) {
 	checksum, err := h.getChecksum(db, tableName)
 	if err != nil {
 		return true, err
@@ -104,16 +104,9 @@ func (h *MySQL) tablesLoaded(db *sql.DB) error {
 }
 
 func (h *MySQL) getChecksum(db *sql.DB, tableName string) (int64, error) {
-	rows, err := db.Query("CHECKSUM TABLE " + h.quoteKeyword(tableName))
-	if err != nil {
-		return 0, err
-	}
-	defer rows.Close()
-	if !rows.Next() {
-		return 0, rows.Err()
-	}
+	row := db.QueryRow("CHECKSUM TABLE " + h.quoteKeyword(tableName))
 	var table string
 	var checksum int64
-	err = rows.Scan(&table, &checksum)
+	err := row.Scan(&table, &checksum)
 	return checksum, err
 }

--- a/mysql.go
+++ b/mysql.go
@@ -8,6 +8,7 @@ import (
 // MySQL is the MySQL helper for this package
 type MySQL struct {
 	baseHelper
+	tableChecksums map[string]int64
 }
 
 func (*MySQL) paramType() int {
@@ -73,4 +74,46 @@ func (h *MySQL) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) (er
 	}
 
 	return tx.Commit()
+}
+
+func (h *MySQL) tableModified(db *sql.DB, tableName string) (bool, error) {
+	checksum, err := h.getChecksum(db, tableName)
+	if err != nil {
+		return true, err
+	}
+	previousChecksum, ok := h.tableChecksums[tableName]
+	return !ok || checksum != previousChecksum, nil
+}
+
+func (h *MySQL) tablesLoaded(db *sql.DB) error {
+	if h.tableChecksums != nil {
+		return nil
+	}
+	tableNames, err := h.tableNames(db)
+	if err != nil {
+		return err
+	}
+	h.tableChecksums = make(map[string]int64, len(tableNames))
+	for _, tableName := range tableNames {
+		h.tableChecksums[tableName], err = h.getChecksum(db, tableName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *MySQL) getChecksum(db *sql.DB, tableName string) (int64, error) {
+	rows, err := db.Query("CHECKSUM TABLE " + h.quoteKeyword(tableName))
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return 0, rows.Err()
+	}
+	var table string
+	var checksum int64
+	err = rows.Scan(&table, &checksum)
+	return checksum, err
 }

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -102,10 +102,11 @@ func (c *Context) Load() error {
 
 	err := c.helper.disableReferentialIntegrity(c.db, func(tx *sql.Tx) error {
 		for _, file := range c.fixturesFiles {
-			modified, err := c.helper.tableModified(c.db, file.fileNameWithoutExtension())
+			modified, err := c.helper.isTableModified(c.db, file.fileNameWithoutExtension())
 			if err != nil {
 				return err
-			} else if !modified {
+			}
+			if !modified {
 				continue
 			}
 			if err := file.delete(tx, c.helper); err != nil {


### PR DESCRIPTION
Use MySQL's `CHECKSUM TABLE <table-name>` to only reload a table if its checksum has changed.

In the future, reload-only-if-modified optimizations could be added for other RDBMSs too.