### PR TITLE
Modify databaseName to surface database errors

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -18,7 +18,7 @@ type Helper interface {
 	init(*sql.DB) error
 	disableReferentialIntegrity(*sql.DB, loadFunction) error
 	paramType() int
-	databaseName(queryable) string
+	databaseName(queryable) (string, error)
 	tableNames(queryable) ([]string, error)
 	isTableModified(queryable, string) (bool, error)
 	afterLoad(queryable) error

--- a/oracle.go
+++ b/oracle.go
@@ -43,9 +43,10 @@ func (*Oracle) quoteKeyword(str string) string {
 	return fmt.Sprintf("\"%s\"", strings.ToUpper(str))
 }
 
-func (*Oracle) databaseName(q queryable) (dbName string) {
-	q.QueryRow("SELECT user FROM DUAL").Scan(&dbName)
-	return
+func (*Oracle) databaseName(q queryable) (string, error) {
+	var dbName string
+	err := q.QueryRow("SELECT user FROM DUAL").Scan(&dbName)
+	return dbName, err
 }
 
 func (*Oracle) tableNames(q queryable) ([]string, error) {

--- a/postgresql.go
+++ b/postgresql.go
@@ -52,9 +52,10 @@ func (*PostgreSQL) paramType() int {
 	return paramTypeDollar
 }
 
-func (*PostgreSQL) databaseName(q queryable) (dbName string) {
-	q.QueryRow("SELECT current_database()").Scan(&dbName)
-	return
+func (*PostgreSQL) databaseName(q queryable) (string, error) {
+	var dbName string
+	err := q.QueryRow("SELECT current_database()").Scan(&dbName)
+	return dbName, err
 }
 
 func (h *PostgreSQL) tableNames(q queryable) ([]string, error) {

--- a/sqlite.go
+++ b/sqlite.go
@@ -14,12 +14,15 @@ func (*SQLite) paramType() int {
 	return paramTypeQuestion
 }
 
-func (*SQLite) databaseName(q queryable) (dbName string) {
+func (*SQLite) databaseName(q queryable) (string, error) {
 	var seq int
-	var main string
-	q.QueryRow("PRAGMA database_list").Scan(&seq, &main, &dbName)
+	var main, dbName string
+	err := q.QueryRow("PRAGMA database_list").Scan(&seq, &main, &dbName)
+	if err != nil {
+		return "", err
+	}
 	dbName = filepath.Base(dbName)
-	return
+	return dbName, nil
 }
 
 func (*SQLite) tableNames(q queryable) ([]string, error) {

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -32,9 +32,10 @@ func (*SQLServer) quoteKeyword(str string) string {
 	return fmt.Sprintf("[%s]", str)
 }
 
-func (*SQLServer) databaseName(q queryable) (dbname string) {
-	q.QueryRow("SELECT DB_NAME()").Scan(&dbname)
-	return
+func (*SQLServer) databaseName(q queryable) (string, error) {
+	var dbName string
+	err := q.QueryRow("SELECT DB_NAME()").Scan(&dbName)
+	return dbName, err
 }
 
 func (*SQLServer) tableNames(q queryable) ([]string, error) {

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -95,7 +95,11 @@ func newContext(db *sql.DB, helper Helper, fixtures []*fixtureFile) (*Context, e
 //     }
 func (c *Context) Load() error {
 	if !skipDatabaseNameCheck {
-		if !dbnameRegexp.MatchString(c.helper.databaseName(c.db)) {
+		dbName, err := c.helper.databaseName(c.db)
+		if err != nil {
+			return err
+		}
+		if !dbnameRegexp.MatchString(dbName) {
 			return ErrNotTestDatabase
 		}
 	}

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -103,6 +103,31 @@ func TestQuoteKeyword(t *testing.T) {
 	}
 }
 
+func TestDatabaseNameHelperSurfacesErrors(t *testing.T) {
+	if len(databases) == 0 {
+		t.Error("No database chosen for tests!")
+	}
+
+	for _, database := range databases {
+		connString := os.Getenv(database.connEnv)
+
+		fmt.Printf("Test for %s\n", database.name)
+
+		db, err := sql.Open(database.name, connString)
+		if err != nil {
+			log.Fatalf("Failed to connect to database: %v\n", err)
+		}
+
+		// Ensure a connection error occurs
+		db.Close()
+
+		_, err = database.helper.databaseName(db)
+		if err == nil {
+			t.Error("Expected databaseName to surface error")
+		}
+	}
+}
+
 func assertCount(t *testing.T, db *sql.DB, h Helper, table string, expectedCount int) {
 	var count int
 


### PR DESCRIPTION
This addresses https://github.com/go-testfixtures/testfixtures/issues/17 by surfacing errors that occur during the `Scan` to read in the database name.