### PR TITLE
Fixed quoting schemas for SQL Server.

### DIFF
--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -92,6 +92,8 @@ func TestQuoteKeyword(t *testing.T) {
 	}{
 		{&PostgreSQL{}, `posts_tags`, `"posts_tags"`},
 		{&PostgreSQL{}, `test_schema.posts_tags`, `"test_schema"."posts_tags"`},
+		{&SQLServer{}, `posts_tags`, `[posts_tags]`},
+		{&SQLServer{}, `test_schema.posts_tags`, `[test_schema].[posts_tags]`},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
With these changes you can use fixture files with schema in name, like a `testdata/fixtures/schema1.table1.yml` which will be applied to `[schema1].[table1]`.