### PR TITLE
Fixed table schema using with SQL Server.

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -32,14 +32,14 @@ type queryable interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }
 
-// BatchSplitter is an interface with method which returns byte slice for
+// batchSplitter is an interface with method which returns byte slice for
 // splitting SQL batches. This need to split sql statements and run its
 // separately.
 //
 // For Microsoft SQL Server batch splitter is "GO". For details see
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/sql-server-utilities-statements-go
-type BatchSplitter interface {
-	Splitter() []byte
+type batchSplitter interface {
+	splitter() []byte
 }
 
 var (

--- a/helper.go
+++ b/helper.go
@@ -32,6 +32,16 @@ type queryable interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }
 
+// BatchSplitter is an interface with method which returns byte slice for
+// splitting SQL batches. This need to split sql statements and run its
+// separately.
+//
+// For Microsoft SQL Server batch splitter is "GO". For details see
+// https://docs.microsoft.com/en-us/sql/t-sql/language-elements/sql-server-utilities-statements-go
+type BatchSplitter interface {
+	Splitter() []byte
+}
+
 var (
 	_ Helper = &MySQL{}
 	_ Helper = &PostgreSQL{}

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -44,7 +44,7 @@ func (*SQLServer) databaseName(q queryable) (string, error) {
 }
 
 func (*SQLServer) tableNames(q queryable) ([]string, error) {
-	rows, err := q.Query("SELECT table_name FROM information_schema.tables")
+	rows, err := q.Query("SELECT table_schema + '.' + table_name FROM information_schema.tables")
 	if err != nil {
 		return nil, err
 	}
@@ -124,4 +124,12 @@ func (h *SQLServer) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction)
 	}
 
 	return tx.Commit()
+}
+
+// Splitter is a BatchSplitter interface implementation. We need it for
+// SQL Server because commands like a `CREATE SCHEMA...` and a `CREATE TABLE...`
+// could not be executed in the same batch.
+// See https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms175502(v=sql.105)#rules-for-using-batches
+func (*SQLServer) Splitter() []byte {
+	return []byte("GO\n")
 }

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -126,10 +126,10 @@ func (h *SQLServer) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction)
 	return tx.Commit()
 }
 
-// Splitter is a BatchSplitter interface implementation. We need it for
+// splitter is a batchSplitter interface implementation. We need it for
 // SQL Server because commands like a `CREATE SCHEMA...` and a `CREATE TABLE...`
 // could not be executed in the same batch.
 // See https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms175502(v=sql.105)#rules-for-using-batches
-func (*SQLServer) Splitter() []byte {
+func (*SQLServer) splitter() []byte {
 	return []byte("GO\n")
 }

--- a/testdata/schema/sqlserver.sql
+++ b/testdata/schema/sqlserver.sql
@@ -1,5 +1,7 @@
-IF OBJECT_ID('x.empty_table_without_fixtures', 'U') IS NOT NULL DROP TABLE x.empty_table_without_fixtures;
-IF EXISTS(SELECT 1 FROM sys.schemas WHERE name = 'x') DROP SCHEMA x;
+IF OBJECT_ID('non_default_schema.empty_table_without_fixtures', 'U') IS NOT NULL
+	DROP TABLE non_default_schema.empty_table_without_fixtures;
+IF EXISTS(SELECT 1 FROM sys.schemas WHERE name = 'non_default_schema')
+	DROP SCHEMA non_default_schema;
 
 IF OBJECT_ID('comments', 'U') IS NOT NULL DROP TABLE comments;
 IF OBJECT_ID('posts_tags', 'U') IS NOT NULL DROP TABLE posts_tags;
@@ -23,12 +25,12 @@ CREATE TABLE tags (
 );
 GO
 
-CREATE SCHEMA x AUTHORIZATION dbo;
+CREATE SCHEMA non_default_schema AUTHORIZATION dbo;
 GO
 
-CREATE TABLE x.empty_table_without_fixtures (
-  id INT IDENTITY PRIMARY KEY
-  ,name VARCHAR(255) NOT NULL
+CREATE TABLE non_default_schema.empty_table_without_fixtures (
+	id INT IDENTITY PRIMARY KEY
+	,name VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE posts_tags (

--- a/testdata/schema/sqlserver.sql
+++ b/testdata/schema/sqlserver.sql
@@ -1,3 +1,6 @@
+IF OBJECT_ID('x.empty_table_without_fixtures', 'U') IS NOT NULL DROP TABLE x.empty_table_without_fixtures;
+IF EXISTS(SELECT 1 FROM sys.schemas WHERE name = 'x') DROP SCHEMA x;
+
 IF OBJECT_ID('comments', 'U') IS NOT NULL DROP TABLE comments;
 IF OBJECT_ID('posts_tags', 'U') IS NOT NULL DROP TABLE posts_tags;
 IF OBJECT_ID('posts', 'U') IS NOT NULL DROP TABLE posts;
@@ -17,6 +20,15 @@ CREATE TABLE tags (
 	,name VARCHAR(255) NOT NULL
 	,created_at DATETIME NOT NULL
 	,updated_at DATETIME NOT NULL
+);
+GO
+
+CREATE SCHEMA x AUTHORIZATION dbo;
+GO
+
+CREATE TABLE x.empty_table_without_fixtures (
+  id INT IDENTITY PRIMARY KEY
+  ,name VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE posts_tags (

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -51,23 +51,21 @@ func TestLoadFixtures(t *testing.T) {
 			log.Fatalf("Failed to ping database: %v\n", err)
 		}
 
-		batches := [][]byte{}
+		var batches [][]byte
 
 		data, err := ioutil.ReadFile(database.schemaFile)
 		if err != nil {
 			log.Fatalf("Could not read file %s: %v\n", database.schemaFile, err)
 		}
 
-		h, ok := database.helper.(BatchSplitter)
-		if ok {
-			batches = append(batches, bytes.Split(data, h.Splitter())...)
+		if h, ok := database.helper.(batchSplitter); ok {
+			batches = append(batches, bytes.Split(data, h.splitter())...)
 		} else {
 			batches = append(batches, data)
 		}
 
 		for _, b := range batches {
-			_, err = db.Exec(string(b))
-			if err != nil {
+			if _, err = db.Exec(string(b)); err != nil {
 				t.Fatalf("Failed to create schema: %v\n", err)
 			}
 		}


### PR DESCRIPTION
Hi!

This PR fixes next bug. If you create any table in database in SQL Server within schema different to `dbo`, for instance `x.empty_table_without_fixtures`, and run tests you'll get an error 

```
% go test -tags sqlserver -v                                                                
=== RUN   TestFixtureFile                                                                                                                                                                     
--- PASS: TestFixtureFile (0.00s)                                                                                
=== RUN   TestLoadFixtures                                                                                           
Test for mssql                                           
--- FAIL: TestLoadFixtures (0.06s)                      
        testfixtures_test.go:150: Error on loading fixtures: mssql: Cannot find the object "empty_table_without_fixtures" because it does not exist or you do not have permissions.
        testfixtures_test.go:139: posts should have 2, but has 0          
        testfixtures_test.go:139: comments should have 4, but has 0                                           
        testfixtures_test.go:139: tags should have 3, but has 0      
        testfixtures_test.go:139: posts_tags should have 2, but has 0
        testfixtures_test.go:139: users should have 2, but has 0          
        testfixtures_test.go:200: Error on loading fixtures: mssql: Cannot find the object "empty_table_without_fixtures" because it does not exist or you do not have permissions.           
        testfixtures_test.go:139: posts should have 2, but has 1
        testfixtures_test.go:139: comments should have 4, but has 0                                                
        testfixtures_test.go:139: tags should have 3, but has 0                                                                                                                               
        testfixtures_test.go:139: posts_tags should have 2, but has 0                                                                                                                         
        testfixtures_test.go:74: mssql: Invalid object name 'empty_table_without_fixtures'.
        testfixtures_test.go:82: mssql: Cannot find the object "empty_table_without_fixtures" because it does not exist or you do not have permissions.
=== RUN   TestQuoteKeyword                           
--- PASS: TestQuoteKeyword (0.00s)                                                             
=== RUN   TestDatabaseNameHelperSurfacesErrors                                                                                                                                                
Test for mssql                                                                                                                                
--- PASS: TestDatabaseNameHelperSurfacesErrors (0.00s)                                                                                                        
FAIL                                                      
exit status 1                                     
FAIL    github.com/go-testfixtures/testfixtures 0.067s
```

... because function [`tableName`](https://github.com/go-testfixtures/testfixtures/blob/master/sqlserver.go#L47) does not support table schema.