### PR TITLE
update go version 1.12 in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - '1.10'
-  - '1.11'
-  - '1.12'
+  - '1.11.x'
+  - '1.12.x'
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - '1.10'
   - '1.11'
+  - '1.12'
 
 services:
   - postgresql


### PR DESCRIPTION
Hi, thanks for your awesome testing library. 

Following Go version updating, I suggest updating Go version 1.12 in ci.

Best,
Kazuki