### PR TITLE
Postgresql: Support for TimescaleDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ testfixtures.ResetSequencesTo(10000)
 
 ## Compatible databases
 
-### PostgreSQL
+### PostgreSQL / TimescaleDB
 
 This package has two approaches to disable foreign keys while importing fixtures
 in PostgreSQL databases:

--- a/postgresql.go
+++ b/postgresql.go
@@ -71,7 +71,8 @@ func (h *PostgreSQL) tableNames(q queryable) ([]string, error) {
 		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
 		WHERE pg_class.relkind = 'r'
 		  AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
-		  AND pg_namespace.nspname NOT LIKE 'pg_toast%';
+		  AND pg_namespace.nspname NOT LIKE 'pg_toast%'
+		  AND pg_namespace.nspname NOT LIKE '\_%';
 	`
 	rows, err := q.Query(sql)
 	if err != nil {
@@ -98,6 +99,7 @@ func (h *PostgreSQL) getSequences(q queryable) ([]string, error) {
 		FROM pg_class
 		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
 		WHERE pg_class.relkind = 'S'
+		  AND pg_namespace.nspname NOT LIKE '\_%'
 	`
 
 	rows, err := q.Query(sql)
@@ -128,6 +130,7 @@ func (*PostgreSQL) getNonDeferrableConstraints(q queryable) ([]pgConstraint, err
 		FROM information_schema.table_constraints
 		WHERE constraint_type = 'FOREIGN KEY'
 		  AND is_deferrable = 'NO'
+		  AND table_schema NOT LIKE '\_%'
   	`
 	rows, err := q.Query(sql)
 	if err != nil {

--- a/postgresql.go
+++ b/postgresql.go
@@ -72,7 +72,7 @@ func (h *PostgreSQL) tableNames(q queryable) ([]string, error) {
 		WHERE pg_class.relkind = 'r'
 		  AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
 		  AND pg_namespace.nspname NOT LIKE 'pg_toast%'
-		  AND pg_namespace.nspname NOT LIKE '\_%';
+		  AND pg_namespace.nspname NOT LIKE '\_timescaledb%';
 	`
 	rows, err := q.Query(sql)
 	if err != nil {
@@ -99,7 +99,7 @@ func (h *PostgreSQL) getSequences(q queryable) ([]string, error) {
 		FROM pg_class
 		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
 		WHERE pg_class.relkind = 'S'
-		  AND pg_namespace.nspname NOT LIKE '\_%'
+		  AND pg_namespace.nspname NOT LIKE '\_timescaledb%'
 	`
 
 	rows, err := q.Query(sql)
@@ -130,7 +130,7 @@ func (*PostgreSQL) getNonDeferrableConstraints(q queryable) ([]pgConstraint, err
 		FROM information_schema.table_constraints
 		WHERE constraint_type = 'FOREIGN KEY'
 		  AND is_deferrable = 'NO'
-		  AND table_schema NOT LIKE '\_%'
+		  AND table_schema NOT LIKE '\_timescaledb%'
   	`
 	rows, err := q.Query(sql)
 	if err != nil {


### PR DESCRIPTION
Hi there, this PR is my attempt to add support in testfixtures for [TimescaleDB](https://www.timescale.com/), a Postgres extension that supports time-series operations & workflows. I really like the idea of testing with a live db data especially when there's complex db functions involved, so testfixtures was a great find. Unfortunately, this library breaks when attempting to restage the timescaledb tables with the error `ERROR: operation not supported on chunk tables`.

TimescaleDB works transparently by manipulating the database, automatically generating partition tables, hooking into the query planner, and other tricks.

```
psql~> \dn
          List of schemas
          Name           |  Owner   
-------------------------+----------
 _timescaledb_cache      | postgres
 _timescaledb_catalog    | postgres
 _timescaledb_config     | postgres
 _timescaledb_internal   | postgres
 public                  | postgres
```
My approach to fix the issue I saw, was to ignore those schemas and let the extension do the book-keeping. Specifically, I added an exclusion for all pg namespaces that are prefixed by underscores (_), which are considered private, off-limits by the extension. This may be kludgy and break existing user's tests if they happen to prefix similar ways, though I've never personally seen that naming strategy used by anyone but applications that mess with postgres internals.

I would be willing to investigate an alternative approach. Such as searching for partition tables that do not support DELETE/TRUNCATE, or adding an option field to the `testfixtures.Helper` to specify a blacklist of table namespaces. Let me know what you think!

---

Another user wondered about Timescale before, #27 . Around that time, I started using this patch with my own projects, and I have seen no unexpected breaks. Testing was done with PG v10 & v11, and the extension for TimescaleDB v0.9 (beta) through v1.4 (current).