### PR TITLE
fix dump data columns sort

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -108,7 +108,7 @@ func (d *Dumper) dumpTable(table string) error {
 		return err
 	}
 
-	fixtures := make([]interface{}, 0, 10)
+	fixtures := make([]yaml.MapSlice, 0, 10)
 	for rows.Next() {
 		entries := make([]interface{}, len(columns))
 		entryPtrs := make([]interface{}, len(entries))
@@ -119,9 +119,12 @@ func (d *Dumper) dumpTable(table string) error {
 			return err
 		}
 
-		entryMap := make(map[string]interface{}, len(entries))
+		entryMap := make([]yaml.MapItem, len(entries))
 		for i, column := range columns {
-			entryMap[column] = convertValue(entries[i])
+			entryMap[i] = yaml.MapItem{
+				Key:   column,
+				Value: convertValue(entries[i]),
+			}
 		}
 		fixtures = append(fixtures, entryMap)
 	}

--- a/dump.go
+++ b/dump.go
@@ -97,7 +97,14 @@ func (d *Dumper) Dump() error {
 
 func (d *Dumper) dumpTable(table string) error {
 	query := fmt.Sprintf("SELECT * FROM %s", d.helper.quoteKeyword(table))
-	rows, err := d.db.Query(query)
+
+	stmt, err := d.db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The currently dumped data columns are out of order, which can be guaranteed by using yaml.MapSlice and yaml.MapItem

