### PR TITLE
add support for mixing files, dirs and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,25 @@ if err != nil {
 }
 ```
 
+With `Paths` option, you can specify the paths that fixtures will load
+from. Path can be directory or file. If directory, we will search YAML files
+in it.
+
+```go
+fixtures, err := testfixtures.New(
+        testfixtures.Database(db),
+        testfixtures.Dialect("postgres"),
+        testfixtures.Paths(
+                "fixtures/orders.yml",
+                "fixtures/customers.yml",
+                "common_fixtures/users"
+        ),
+)
+if err != nil {
+        ...
+}
+```
+
 ## Security check
 
 In order to prevent you from accidentally wiping the wrong database, this

--- a/cmd/testfixtures/testfixtures.go
+++ b/cmd/testfixtures/testfixtures.go
@@ -26,6 +26,7 @@ func main() {
 		connString            string
 		dir                   string
 		files                 []string
+		paths                 []string
 		useAlterContraint     bool
 		skipResetSequences    bool
 		resetSequencesTo      int64
@@ -37,6 +38,7 @@ func main() {
 	pflag.StringVarP(&connString, "conn", "c", "", "a database connection string")
 	pflag.StringVarP(&dir, "dir", "D", "", "a directory of YAML fixtures to load")
 	pflag.StringSliceVarP(&files, "files", "f", nil, "a list of YAML files to load")
+	pflag.StringSliceVarP(&paths, "paths", "p", nil, "a list of fixture paths to load (directory or file)")
 	pflag.BoolVar(&useAlterContraint, "alter-constraint", false, "use ALTER CONSTRAINT to disable referential integrity (PostgreSQL only)")
 	pflag.BoolVar(&skipResetSequences, "no-reset-sequences", false, "skip reset of sequences after loading (PostgreSQL only)")
 	pflag.Int64Var(&resetSequencesTo, "reset-sequences-to", 0, "sets the number sequences will be reset after loading fixtures (PostgreSQL only, defaults to 10000)")
@@ -52,12 +54,8 @@ func main() {
 		log.Fatal("testfixtures: both --dialect (-d) and --conn (-c) are required")
 		return
 	}
-	if dir == "" && len(files) == 0 {
-		log.Fatal("testfixtures: either --dir (-D) or --files (-f) need to be given")
-		return
-	}
-	if dir != "" && len(files) > 0 {
-		log.Fatal("testfixtures: you can use --dir (-D) and --files (-f) together")
+	if dir == "" && len(files) == 0 && len(paths) == 0 {
+		log.Fatal("testfixtures: either --dir (-D) or --files (-f) or --paths (-p) need to be given")
 		return
 	}
 
@@ -85,8 +83,12 @@ func main() {
 	}
 	if dir != "" {
 		options = append(options, testfixtures.Directory(dir))
-	} else {
+	}
+	if len(files) > 0 {
 		options = append(options, testfixtures.Files(files...))
+	}
+	if len(paths) > 0 {
+		options = append(options, testfixtures.Paths(paths...))
 	}
 	if useAlterContraint {
 		options = append(options, testfixtures.UseAlterConstraint())

--- a/testdata/fixtures_dirs/fixtures1/comments.yml
+++ b/testdata/fixtures_dirs/fixtures1/comments.yml
@@ -1,0 +1,31 @@
+- id: 1
+  post_id: 1
+  content: Post 1 comment 1
+  author_name: John Doe
+  author_email: john@doe.com
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+- id: 2
+  post_id: 2
+  content: Post 1 comment 2
+  author_name: John Doe
+  author_email: john@doe.com
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+- id: 3
+  post_id: 2
+  content: Post 2 comment 1
+  author_name: John Doe
+  author_email: john@doe.com
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+- id: 4
+  post_id: 2
+  content: Post 2 comment 2
+  author_name: John Doe
+  author_email: john@doe.com
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12

--- a/testdata/fixtures_dirs/fixtures1/posts.yml
+++ b/testdata/fixtures_dirs/fixtures1/posts.yml
@@ -1,0 +1,13 @@
+one:
+  id: 1
+  title: Post 1
+  content: Post 1 content
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+two:
+  id: 2
+  title: Post 2
+  content: Post 2 content
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12

--- a/testdata/fixtures_dirs/fixtures1/posts_tags.yml
+++ b/testdata/fixtures_dirs/fixtures1/posts_tags.yml
@@ -1,0 +1,6 @@
+{{range $postId := $.PostIds}}
+{{range $tagId := $.TagIds}}
+- post_id: {{$postId}}
+  tag_id: {{$tagId}}
+{{end}}
+{{end}}

--- a/testdata/fixtures_dirs/fixtures2/tags.yml
+++ b/testdata/fixtures_dirs/fixtures2/tags.yml
@@ -1,0 +1,17 @@
+one:
+  id: 1
+  name: Go
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+two:
+  id: 2
+  name: Ruby
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12
+
+three:
+  id: 3
+  name: Java
+  created_at: 2016-01-01 12:30:12
+  updated_at: 2016-01-01 12:30:12

--- a/testdata/fixtures_dirs/fixtures2/users.yml
+++ b/testdata/fixtures_dirs/fixtures2/users.yml
@@ -1,0 +1,22 @@
+# JSON object
+- id: 1
+  attributes:
+    name: John
+    surname: Due
+    age: 20
+    favorite_color:
+      - blue
+      - red
+      - yellow
+
+# JSON array
+- id: 2
+  attributes:
+    - foo
+    - bar
+    - baz:
+      foobar: foobaz
+      arr:
+        - 1
+        - 2
+        - 3

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -103,6 +103,32 @@ func testLoader(t *testing.T, dialect, connStr, schemaFilePath string, additiona
 		assertFixturesLoaded(t, l)
 	})
 
+	t.Run("LoadFromDirectory-Multiple", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Directory("testdata/fixtures_dirs/fixtures1"),
+				Directory("testdata/fixtures_dirs/fixtures2"),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
 	t.Run("LoadFromFiles", func(t *testing.T) {
 		options := append(
 			[]func(*Loader) error{
@@ -119,6 +145,156 @@ func testLoader(t *testing.T, dialect, connStr, schemaFilePath string, additiona
 					"testdata/fixtures/tags.yml",
 					"testdata/fixtures/posts_tags.yml",
 					"testdata/fixtures/users.yml",
+				),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
+	t.Run("LoadFromFiles-Multiple", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Files(
+					"testdata/fixtures/posts.yml",
+					"testdata/fixtures/comments.yml",
+				),
+				Files(
+					"testdata/fixtures/tags.yml",
+					"testdata/fixtures/posts_tags.yml",
+					"testdata/fixtures/users.yml",
+				),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
+	t.Run("LoadFromDirectoryAndFiles", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Directory("testdata/fixtures_dirs/fixtures1"),
+				Files(
+					"testdata/fixtures/tags.yml",
+					"testdata/fixtures/users.yml",
+				),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
+	t.Run("LoadFromPaths", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Paths(
+					"testdata/fixtures_dirs/fixtures1",
+					"testdata/fixtures_dirs/fixtures2/tags.yml",
+					"testdata/fixtures_dirs/fixtures2/users.yml",
+				),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
+	t.Run("LoadFromPaths-OnlyFiles", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Paths(
+					"testdata/fixtures/posts.yml",
+					"testdata/fixtures/comments.yml",
+					"testdata/fixtures/tags.yml",
+					"testdata/fixtures/posts_tags.yml",
+					"testdata/fixtures/users.yml",
+				),
+			},
+			additionalOptions...,
+		)
+		l, err := New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+		assertFixturesLoaded(t, l)
+	})
+
+	t.Run("LoadFromPaths-OnlyDirs", func(t *testing.T) {
+		options := append(
+			[]func(*Loader) error{
+				Database(db),
+				Dialect(dialect),
+				Template(),
+				TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				Paths(
+					"testdata/fixtures_dirs/fixtures1",
+					"testdata/fixtures_dirs/fixtures2",
 				),
 			},
 			additionalOptions...,


### PR DESCRIPTION
Hi All,
Initially, I want to thank you all for creating this library. It's really making easier testing with the database.

In the current implementation, it's not allowed
 - adding directory and files at the same time.
 - adding multiple directories
 - adding multiple files 

In some cases, you can want to use common fixtures (ex: users.yml, phones.yml) and test-specific fixtures at the same time to avoid fixture duplication.  I really don't know why testfixtures does not have this feature. If is there any specific reason for that, please let me know. 

This PR adds support for:
- adding directory and files at the same time
- adding multiple directories
- adding multiple files 
- adding paths

`Paths(paths ...string)` can be thinking as the abbreviation of the not-allowed features that I listed above.
