### PR TITLE
null checksum

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -128,7 +128,7 @@ func (h *mySQL) getChecksum(q queryable, tableName string) (int64, error) {
 		return 0, err
 	}
 	if !checksum.Valid {
-		return 0, fmt.Errorf("table %s does not exist", tableName)
+		return 0, fmt.Errorf("testfixtures: table %s does not exist", tableName)
 	}
 	return checksum.Int64, nil
 }

--- a/mysql.go
+++ b/mysql.go
@@ -119,13 +119,16 @@ func (h *mySQL) afterLoad(q queryable) error {
 }
 
 func (h *mySQL) getChecksum(q queryable, tableName string) (int64, error) {
-	sql := fmt.Sprintf("CHECKSUM TABLE %s", h.quoteKeyword(tableName))
+	query := fmt.Sprintf("CHECKSUM TABLE %s", h.quoteKeyword(tableName))
 	var (
 		table    string
-		checksum int64
+		checksum sql.NullInt64
 	)
-	if err := q.QueryRow(sql).Scan(&table, &checksum); err != nil {
+	if err := q.QueryRow(query).Scan(&table, &checksum); err != nil {
 		return 0, err
 	}
-	return checksum, nil
+	if !checksum.Valid {
+		return 0, fmt.Errorf("table %s does not exist", tableName)
+	}
+	return checksum.Int64, nil
 }


### PR DESCRIPTION
Right now if you try to get the checksum of a table that does not exist, you will get the following error as  Checksum will be null.

```
panic: sql: Scan error on column index 1, name "Checksum": converting NULL to int64 is unsupported
```

The message is not clear and does not help to identify whats really wrong.