### PR TITLE
Add support for CockroachDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The file would look like this (it can have as many record you want):
 ```
 
 An YAML object or array will be converted to JSON. It will be stored on a native
-JSON type like JSONB on PostgreSQL or as a TEXT or VARCHAR column on other
+JSON type like JSONB on PostgreSQL and CockroachDB or as a TEXT or VARCHAR column on other
 databases.
 
 ```yml
@@ -290,6 +290,21 @@ testfixtures.New(
 
 Tested using the [github.com/lib/pq](https://github.com/lib/pq) driver.
 
+### CockroachDB
+
+This package drops foreign keys while importing fixtures and recreate it after import.
+
+To use:
+
+```go
+testfixtures.New(
+        ...
+        testfixtures.Dialect("cockroachdb"), // or "cockroachdb"
+)
+```
+
+Tested using the [github.com/lib/pq](https://github.com/lib/pq) and [github.com/jackc/pgx](https://github.com/jackc/pgx) drivers.
+
 ### MySQL / MariaDB
 
 Just make sure the connection string have
@@ -453,6 +468,7 @@ for the database you want to run tests against:
 
 ```bash
 task test:pg # PostgreSQL
+task test:crdb # Cockroach
 task test:mysql # MySQL
 task test:sqlite # SQLite
 task test:sqlserver # Microsoft SQL Server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,12 @@ tasks:
       - task: test-db
         vars: {DATABASE: postgresql}
 
+  test:crdb:
+    desc: Test CockroachDB
+    cmds:
+      - task: test-db
+        vars: {DATABASE: cockroachdb}
+
   test:mysql:
     desc: Test MySQL
     cmds:
@@ -56,4 +62,4 @@ tasks:
   docker:test:
     cmds:
       - docker-compose down -v
-      - docker-compose run testfixtures go test -v -tags 'postgresql sqlite mysql sqlserver'
+      - docker-compose run testfixtures go test -v -tags 'postgresql sqlite mysql sqlserver cockroachdb'

--- a/cmd/testfixtures/testfixtures.go
+++ b/cmd/testfixtures/testfixtures.go
@@ -59,13 +59,18 @@ func main() {
 		return
 	}
 
+	driver := dialect
+	if driver == "cockroach" || driver == "cockroachdb" {
+		driver = "postgres"
+	}
+
 	dialect, err := getDialect(dialect)
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	db, err := sql.Open(dialect, connString)
+	db, err := sql.Open(driver, connString)
 	if err != nil {
 		log.Fatalf("testfixtures: could not connect to database: %v", err)
 		return
@@ -117,6 +122,8 @@ func getDialect(dialect string) (string, error) {
 	switch dialect {
 	case "postgres", "postgresql", "timescaledb":
 		return "postgres", nil
+	case "cockroach", "cockroachdb":
+		return "cockroachdb", nil
 	case "mysql", "mariadb":
 		return "mysql", nil
 	case "sqlite", "sqlite3":

--- a/cockroachdb.go
+++ b/cockroachdb.go
@@ -1,0 +1,226 @@
+package testfixtures
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const fkName string = "FOREIGN KEY"
+
+type cockroachDB struct {
+	baseHelper
+
+	skipResetSequences bool
+	resetSequencesTo   int64
+
+	constraints []crdbConstraint
+
+	tables    []string
+	sequences []string
+}
+
+type crdbConstraint struct {
+	tableName      string
+	constraintName string
+	constraintType string
+	details        string
+	validated      bool
+}
+
+func (h *cockroachDB) init(db *sql.DB) error {
+	var err error
+
+	h.tables, err = h.tableNames(db)
+	if err != nil {
+		return err
+	}
+
+	h.sequences, err = h.getSequences(db)
+	if err != nil {
+		return err
+	}
+
+	h.constraints, err = h.getConstraints(db)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (*cockroachDB) paramType() int {
+	return paramTypeDollar
+}
+
+func (*cockroachDB) databaseName(q queryable) (string, error) {
+	var dbName string
+	err := q.QueryRow("SELECT current_database()").Scan(&dbName)
+	return dbName, err
+}
+
+func (h *cockroachDB) tableNames(q queryable) ([]string, error) {
+	var tables []string
+
+	sql := `
+	        SELECT pg_namespace.nspname || '.' || pg_class.relname
+		FROM pg_class
+		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+		WHERE pg_class.relkind = 'r'
+		  AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+		  AND pg_namespace.nspname NOT LIKE 'pg_toast%'
+		  AND pg_namespace.nspname NOT LIKE 'crdb_internal%'
+		  AND pg_namespace.nspname NOT LIKE '\_timescaledb%';
+	`
+	rows, err := q.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var table string
+		if err = rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+func (h *cockroachDB) getConstraints(q queryable) ([]crdbConstraint, error) {
+	var constraints []crdbConstraint
+
+	for _, table := range h.tables {
+		sql := "SHOW CONSTRAINTS FROM %s;"
+		rows, err := q.Query(fmt.Sprintf(sql, table))
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var constraint crdbConstraint
+			if err = rows.Scan(&constraint.tableName,
+				&constraint.constraintName,
+				&constraint.constraintType,
+				&constraint.details,
+				&constraint.validated); err != nil {
+				return nil, err
+			}
+			if constraint.constraintType == fkName {
+				constraints = append(constraints, constraint)
+			}
+		}
+
+		_ = rows.Close()
+		if err = rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return constraints, nil
+}
+
+func (h *cockroachDB) getSequences(q queryable) ([]string, error) {
+	const sql = `
+		SELECT pg_namespace.nspname || '.' || pg_class.relname AS sequence_name
+		FROM pg_class
+		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+		WHERE pg_class.relkind = 'S'
+		  AND pg_namespace.nspname NOT LIKE '\_timescaledb%'
+	`
+
+	rows, err := q.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var sequences []string
+	for rows.Next() {
+		var sequence string
+		if err = rows.Scan(&sequence); err != nil {
+			return nil, err
+		}
+		sequences = append(sequences, sequence)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return sequences, nil
+}
+
+func (h *cockroachDB) dropAndRecreateConstraints(db *sql.DB, loadFn loadFunction) (err error) {
+	defer func() {
+		// recreate constraints again after load
+		var sql string
+		for _, constraint := range h.constraints {
+			sql += fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s %s;",
+				h.quoteKeyword(constraint.tableName),
+				h.quoteKeyword(constraint.constraintName),
+				constraint.details)
+		}
+		if _, err2 := db.Exec(sql); err2 != nil && err == nil {
+			err = err2
+		}
+	}()
+
+	var sql string
+	for _, constraint := range h.constraints {
+		sql += fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s;", h.quoteKeyword(constraint.tableName), h.quoteKeyword(constraint.constraintName))
+	}
+	if _, err := db.Exec(sql); err != nil {
+		return err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err = loadFn(tx); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (h *cockroachDB) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) (err error) {
+	// ensure sequences being reset after load
+	if !h.skipResetSequences {
+		defer func() {
+			if err2 := h.resetSequences(db); err2 != nil && err == nil {
+				err = err2
+			}
+		}()
+	}
+
+	return h.dropAndRecreateConstraints(db, loadFn)
+
+}
+
+func (h *cockroachDB) resetSequences(db *sql.DB) error {
+	resetSequencesTo := h.resetSequencesTo
+	if resetSequencesTo == 0 {
+		resetSequencesTo = 10000
+	}
+
+	for _, sequence := range h.sequences {
+		_, err := db.Exec(fmt.Sprintf("SELECT SETVAL('%s', %d)", sequence, resetSequencesTo))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (*cockroachDB) quoteKeyword(s string) string {
+	parts := strings.Split(s, ".")
+	for i, p := range parts {
+		parts[i] = fmt.Sprintf(`"%s"`, p)
+	}
+	return strings.Join(parts, ".")
+}

--- a/cockroachdb_test.go
+++ b/cockroachdb_test.go
@@ -1,0 +1,24 @@
+// +build cockroachdb
+
+package testfixtures
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/jackc/pgx/v4/stdlib"
+	_ "github.com/lib/pq"
+)
+
+func TestCockroachDB(t *testing.T) {
+	for _, driver := range []string{"postgres", "pgx"} {
+		testLoader(
+			t,
+			"cockroachdb",
+			driver,
+			os.Getenv("CRDB_CONN_STRING"),
+			"testdata/schema/postgresql.sql",
+			DangerousSkipTestDatabaseCheck(),
+		)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - postgresql
       - mysql
       - sqlserver
+      - cockroachdb
     environment:
       PGPASSWORD: postgres
       PG_CONN_STRING: host=postgresql user=postgres dbname=testfixtures_test port=5432 sslmode=disable
@@ -16,6 +17,8 @@ services:
       SQLITE_CONN_STRING: testfixtures_test.sqlite3
 
       SQLSERVER_CONN_STRING: server=sqlserver;database=master;user id=sa;password=SQL@1server;encrypt=disable
+
+      CRDB_CONN_STRING: host=cockroachdb user=root dbname=defaultdb port=26257 sslmode=disable
 
   postgresql:
     image: postgres:12.1-alpine
@@ -35,3 +38,7 @@ services:
     environment:
       ACCEPT_EULA: 'Y'
       SA_PASSWORD: SQL@1server
+
+  cockroachdb:
+    image: cockroachdb/cockroach:v20.1.3
+    command: start-single-node --store /cockroach-data --insecure --advertise-host cockroachdb

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -13,6 +13,7 @@ func TestMySQL(t *testing.T) {
 	testLoader(
 		t,
 		"mysql",
+		"mysql",
 		os.Getenv("MYSQL_CONN_STRING"),
 		"testdata/schema/mysql.sql",
 	)

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -15,6 +15,7 @@ func TestPostgreSQL(t *testing.T) {
 		testLoader(
 			t,
 			dialect,
+			dialect,
 			os.Getenv("PG_CONN_STRING"),
 			"testdata/schema/postgresql.sql",
 		)
@@ -25,6 +26,7 @@ func TestPostgreSQLWithAlterConstraint(t *testing.T) {
 	for _, dialect := range []string{"postgres", "pgx"} {
 		testLoader(
 			t,
+			dialect,
 			dialect,
 			os.Getenv("PG_CONN_STRING"),
 			"testdata/schema/postgresql.sql",

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -13,6 +13,7 @@ func TestSQLite(t *testing.T) {
 	testLoader(
 		t,
 		"sqlite3",
+		"sqlite3",
 		os.Getenv("SQLITE_CONN_STRING"),
 		"testdata/schema/sqlite.sql",
 	)

--- a/sqlserver_test.go
+++ b/sqlserver_test.go
@@ -13,6 +13,7 @@ func TestSQLServer(t *testing.T) {
 	testLoader(
 		t,
 		"sqlserver",
+		"sqlserver",
 		os.Getenv("SQLSERVER_CONN_STRING"),
 		"testdata/schema/sqlserver.sql",
 		DangerousSkipTestDatabaseCheck(),
@@ -22,6 +23,7 @@ func TestSQLServer(t *testing.T) {
 func TestDeprecatedMssql(t *testing.T) {
 	testLoader(
 		t,
+		"mssql",
 		"mssql",
 		os.Getenv("SQLSERVER_CONN_STRING"),
 		"testdata/schema/sqlserver.sql",

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -117,6 +117,8 @@ func helperForDialect(dialect string) (helper, error) {
 		return &sqlite{}, nil
 	case "mssql", "sqlserver":
 		return &sqlserver{}, nil
+	case "cockroach", "cockroachdb":
+		return &cockroachDB{}, nil
 	default:
 		return nil, fmt.Errorf(`testfixtures: unrecognized dialect "%s"`, dialect)
 	}

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -36,8 +36,8 @@ func TestRequiredOptions(t *testing.T) {
 	})
 }
 
-func testLoader(t *testing.T, dialect, connStr, schemaFilePath string, additionalOptions ...func(*Loader) error) {
-	db, err := sql.Open(dialect, connStr)
+func testLoader(t *testing.T, dialect, driver, connStr, schemaFilePath string, additionalOptions ...func(*Loader) error) {
+	db, err := sql.Open(driver, connStr)
 	if err != nil {
 		t.Errorf("failed to open database: %v", err)
 		return


### PR DESCRIPTION
Since CockroachDB does not yet support [disabling triggers](https://github.com/cockroachdb/cockroach/issues/19444) or [deferrable constraints](https://github.com/cockroachdb/cockroach/issues/31632), I added specific crdb helper that drops fk constraints and recreate it after loading.