### PR TITLE
Fix error when uploading fixtures in sqlserver database with Views

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-testfixtures/testfixtures/v3
+module github.com/yakartoev/testfixtures/v3
 
 require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -56,7 +56,7 @@ func (*sqlserver) databaseName(q queryable) (string, error) {
 }
 
 func (*sqlserver) tableNames(q queryable) ([]string, error) {
-	rows, err := q.Query("SELECT table_schema + '.' + table_name FROM information_schema.tables WHERE table_name <> 'spt_values'")
+	rows, err := q.Query("SELECT table_schema + '.' + table_name FROM information_schema.tables WHERE table_name <> 'spt_values' AND table_type = 'BASE TABLE'")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If you have views in your database, occured error "Cannot alter 'View name' because it is not a table.", this PR fixes it