### PR TITLE
support byte array types storage/loading

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -1,0 +1,14 @@
+package testfixtures
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+func (l *Loader) tryHexStringToBytes(s string) ([]byte, error) {
+	if !strings.HasPrefix(s, "0x") {
+		return nil, fmt.Errorf("not a hexadecimal string, must be prefix 0x")
+	}
+	return hex.DecodeString(strings.TrimPrefix(s, "0x"))
+}

--- a/dump.go
+++ b/dump.go
@@ -2,6 +2,7 @@ package testfixtures
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -160,6 +161,7 @@ func convertValue(value interface{}) interface{} {
 		if utf8.Valid(v) {
 			return string(v)
 		}
+		return "0x" + hex.EncodeToString(value.([]byte))
 	}
 	return value
 }

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -496,8 +496,9 @@ func (l *Loader) buildInsertSQL(f *fixtureFile, record map[interface{}]interface
 				sqlValues = append(sqlValues, strings.TrimPrefix(v, "RAW="))
 				continue
 			}
-
-			if t, err := l.tryStrToDate(v); err == nil {
+			if b, err := l.tryHexStringToBytes(v); err == nil {
+				value = b
+			} else if t, err := l.tryStrToDate(v); err == nil {
 				value = t
 			}
 		case []interface{}, map[interface{}]interface{}:


### PR DESCRIPTION
byte array dumping as hexadecimal string and loading from string as byte array
related to https://github.com/go-testfixtures/testfixtures/issues/48