### PR TITLE
Fixed shadowed variable in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ func TestMain(m *testing.M) {
                 ...
         }
 
-        fixtures, err := testfixtures.New(
+        fixtures, err = testfixtures.New(
                 testfixtures.Database(db), // You database connection
                 testfixtures.Dialect("postgres"), // Available: "postgresql", "timescaledb", "mysql", "mariadb", "sqlite" and "sqlserver"
                 testfixtures.Directory("testdata/fixtures"), // the directory containing the YAML files


### PR DESCRIPTION
The colon needs to be removed in this example code, otherwise we're creating a new variable named `fixtures`, overwriting the initial declaration in the var () declaration bloc.