### PR TITLE
FS loader

### DIFF
--- a/default_fs.go
+++ b/default_fs.go
@@ -1,0 +1,13 @@
+package testfixtures
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type defaultFS struct{}
+
+func (defaultFS) Open(name string) (fs.File, error) {
+	return os.Open(filepath.FromSlash(name))
+}

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -32,6 +32,8 @@ type Loader struct {
 	templateRightDelim string
 	templateOptions    []string
 	templateData       interface{}
+
+	fs fs.FS
 }
 
 type fixtureFile struct {
@@ -60,6 +62,7 @@ func New(options ...func(*Loader) error) (*Loader, error) {
 		templateLeftDelim:  "{{",
 		templateRightDelim: "}}",
 		templateOptions:    []string{"missingkey=zero"},
+		fs:                 defaultFS{},
 	}
 
 	for _, option := range options {
@@ -83,6 +86,17 @@ func New(options ...func(*Loader) error) (*Loader, error) {
 	}
 
 	return l, nil
+}
+
+// FS sets other fs.FS implementation
+//
+// Example embed.FS
+// By default usage os package implementation
+func FS(fs fs.FS) func(*Loader) error {
+	return func(l *Loader) error {
+		l.fs = fs
+		return nil
+	}
 }
 
 // Database sets an existing sql.DB instant to Loader.
@@ -551,7 +565,7 @@ func (l *Loader) buildInsertSQL(f *fixtureFile, record map[interface{}]interface
 }
 
 func (l *Loader) fixturesFromDir(dir string) ([]*fixtureFile, error) {
-	fileinfos, err := ioutil.ReadDir(dir)
+	fileinfos, err := fs.ReadDir(l.fs, dir)
 	if err != nil {
 		return nil, fmt.Errorf(`testfixtures: could not stat directory "%s": %w`, dir, err)
 	}
@@ -565,7 +579,7 @@ func (l *Loader) fixturesFromDir(dir string) ([]*fixtureFile, error) {
 				path:     path.Join(dir, fileinfo.Name()),
 				fileName: fileinfo.Name(),
 			}
-			fixture.content, err = ioutil.ReadFile(fixture.path)
+			fixture.content, err = fs.ReadFile(l.fs, fixture.path)
 			if err != nil {
 				return nil, fmt.Errorf(`testfixtures: could not read file "%s": %w`, fixture.path, err)
 			}
@@ -589,7 +603,7 @@ func (l *Loader) fixturesFromFiles(fileNames ...string) ([]*fixtureFile, error) 
 			path:     f,
 			fileName: filepath.Base(f),
 		}
-		fixture.content, err = ioutil.ReadFile(fixture.path)
+		fixture.content, err = fs.ReadFile(l.fs, fixture.path)
 		if err != nil {
 			return nil, fmt.Errorf(`testfixtures: could not read file "%s": %w`, fixture.path, err)
 		}
@@ -641,7 +655,7 @@ func (l *Loader) fixturesFromFilesMultiTables(fileNames ...string) ([]*fixtureFi
 			err     error
 		)
 
-		content, err = ioutil.ReadFile(f)
+		content, err = fs.ReadFile(l.fs, f)
 		if err != nil {
 			return nil, fmt.Errorf(`testfixtures: could not read file "%s": %w`, f, err)
 		}

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 //go:embed testdata
-var fixtures embed.FS
+var fixtures embed.FS //nolint:unused
 
 func TestFixtureFile(t *testing.T) {
 	f := &fixtureFile{fileName: "posts.yml"}


### PR DESCRIPTION
I often use the testfixtures library. 
Often the data is in the same shared folder, but the tests are in different folders. Because of this you have to use ugly paths.
To solve this problem, I decided to add the ability to pin the target path using fs.FS.

With this simple solution, you can fix the target path for finding fixtures. At least the paths in the tests will look nice. As a maximum, you no longer have to mess with `../`