### PR TITLE
add arm/arm64 goarch for M1 chip compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,10 @@ build:
   goarch:
     - 386
     - amd64
+    - arm
+    - arm64
+  goarm:
+    - 7
   ignore:
     - goos: darwin
       goarch: 386


### PR DESCRIPTION
Fixes #149 

Build ARM and ARM64 arch, usefull for Macbook Pro M1 chip compatibility.