### PR TITLE
WIP: Feature: support bulk insert to speed insert times

### DIFF
--- a/testfixtures.go
+++ b/testfixtures.go
@@ -698,7 +698,7 @@ func (l *Loader) paramSQL(index int) string {
 	case paramTypeDollar:
 		return fmt.Sprintf("$%d", index)
 	case paramTypeAtSign:
-		fmt.Sprintf("@p%d", index
+		return fmt.Sprintf("@p%d", index)
 	default:
 		return "?"
 	}


### PR DESCRIPTION
# Description

## Overview
This pull request introduces a new feature to the fixture library, enabling bulk inserts for fixture files. Prior to this enhancement, inserts were performed sequentially, leading to potential performance bottlenecks, especially with large datasets. The new functionality allows users to opt for bulk inserts, significantly improving the efficiency of the fixture loading process.

## Changes Made
Added a functional option parameter UseBulkInsert() to allow bulk inserting for fixture files.

Modified the implementation to group records with exactly same columns together for efficient bulk inserts when this parameter is set to true.

Also add a free new STRING= like RAW= because I was in trouble this last days due to time conversion for string ids... So with this new "annotation" it solve the problem. 
## Benefits
Improved performance by enabling bulk inserts.

Maintained flexibility by allowing users to choose between sequential and bulk inserts using the UseBulkInsert() functional option (mostely because I write this for postgres in the first place and I don't know if it works for other databse right now)


Feedback and suggestions for further improvements are welcome!


---- 

Not tested right now but this is coming. 

