### PR TITLE
feat: skip call to db for checksum, if not needed

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -117,14 +117,16 @@ func (h *mySQL) resetSequences(db *sql.DB) error {
 }
 
 func (h *mySQL) isTableModified(q queryable, tableName string) (bool, error) {
+	oldChecksum, found := h.tablesChecksum[tableName]
+	if !found {
+		return true, nil
+	}
+
 	checksum, err := h.getChecksum(q, tableName)
 	if err != nil {
 		return true, err
 	}
-
-	oldChecksum := h.tablesChecksum[tableName]
-
-	return oldChecksum == 0 || checksum != oldChecksum, nil
+	return checksum != oldChecksum, nil
 }
 
 func (h *mySQL) afterLoad(q queryable) error {

--- a/postgresql.go
+++ b/postgresql.go
@@ -349,14 +349,16 @@ func (h *postgreSQL) resetSequences(db *sql.DB) error {
 }
 
 func (h *postgreSQL) isTableModified(q queryable, tableName string) (bool, error) {
-	checksum, err := h.getChecksum(q, tableName)
-	if err != nil {
-		return false, err
+	oldChecksum, found := h.tablesChecksum[tableName]
+	if !found {
+		return true, nil
 	}
 
-	oldChecksum := h.tablesChecksum[tableName]
-
-	return oldChecksum == "" || checksum != oldChecksum, nil
+	checksum, err := h.getChecksum(q, tableName)
+	if err != nil {
+		return true, err
+	}
+	return checksum != oldChecksum, nil
 }
 
 func (h *postgreSQL) afterLoad(q queryable) error {


### PR DESCRIPTION
move `oldChecksum == 0` check before calling a database, which saves number of queries made to db