### PR TITLE
chore(ci): use `docker compose` instead of `docker-compose`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,5 +72,5 @@ tasks:
 
   docker:test:
     cmds:
-      - docker-compose down -v --remove-orphans
-      - docker-compose run testfixtures go test -v -tags 'postgresql sqlite mysql sqlserver cockroachdb clickhouse'
+      - docker compose down -v --remove-orphans
+      - docker compose run testfixtures go test -v -tags 'postgresql sqlite mysql sqlserver cockroachdb clickhouse'


### PR DESCRIPTION
https://github.com/go-testfixtures/testfixtures/pull/213 is failing, probably due to deprecation of the `docker-compose` command due to https://www.docker.com/blog/announcing-compose-v2-general-availability/