### PR TITLE
chore: remove ClickHouse underscore import

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -3,8 +3,6 @@ package testfixtures
 import (
 	"database/sql"
 	"fmt"
-
-	_ "github.com/ClickHouse/clickhouse-go/v2"
 )
 
 type clickhouse struct {


### PR DESCRIPTION
rationale: clients open `*db.SQL` on it own, so it is not in a scope of library to import particular db driver