### PR TITLE
test: remove private api usages in tests

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -84,12 +84,6 @@ func (h *clickhouse) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction
 	return tx.Commit()
 }
 
-// splitter is a batchSplitter interface implementation. We need it for
-// ClickHouseDB because clickhouse doesn't support multi-statements.
-func (*clickhouse) splitter() []byte {
-	return []byte(";\n")
-}
-
 func (h *clickhouse) cleanTableQuery(tableName string) string {
 	if h.cleanTableFn == nil {
 		return h.baseHelper.cleanTableQuery(tableName)

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -1,5 +1,4 @@
 //go:build clickhouse
-// +build clickhouse
 
 package testfixtures
 
@@ -11,10 +10,7 @@ import (
 )
 
 func TestClickhouse(t *testing.T) {
-	testLoader(
-		t,
-		"clickhouse",
-		os.Getenv("CLICKHOUSE_CONN_STRING"),
-		"testdata/schema/clickhouse.sql",
-	)
+	db := openDB(t, "clickhouse", os.Getenv("CLICKHOUSE_CONN_STRING"))
+	loadSchemaInBatchesBySplitter(t, db, "testdata/schema/clickhouse.sql", []byte(";\n"))
+	testLoader(t, db, "clickhouse")
 }

--- a/cockroachdb_test.go
+++ b/cockroachdb_test.go
@@ -1,5 +1,4 @@
 //go:build cockroachdb
-// +build cockroachdb
 
 package testfixtures
 
@@ -13,11 +12,12 @@ import (
 
 func TestCockroachDB(t *testing.T) {
 	for _, dialect := range []string{"postgres", "pgx"} {
+		db := openDB(t, dialect, os.Getenv("CRDB_CONN_STRING"))
+		loadSchemaInOneQuery(t, db, "testdata/schema/cockroachdb.sql")
 		testLoader(
 			t,
+			db,
 			dialect,
-			os.Getenv("CRDB_CONN_STRING"),
-			"testdata/schema/cockroachdb.sql",
 			DangerousSkipTestDatabaseCheck(),
 			UseDropConstraint(),
 		)

--- a/helper.go
+++ b/helper.go
@@ -34,16 +34,6 @@ type queryable interface {
 	QueryRow(string, ...interface{}) *sql.Row
 }
 
-// batchSplitter is an interface with method which returns byte slice for
-// splitting SQL batches. This need to split sql statements and run its
-// separately.
-//
-// For Microsoft SQL Server batch splitter is "GO". For details see
-// https://docs.microsoft.com/en-us/sql/t-sql/language-elements/sql-server-utilities-statements-go
-type batchSplitter interface { //nolint
-	splitter() []byte
-}
-
 var (
 	_ helper = &clickhouse{}
 	_ helper = &spanner{}

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -1,4 +1,4 @@
-// +build mysql
+//go:build mysql
 
 package testfixtures
 
@@ -10,10 +10,7 @@ import (
 )
 
 func TestMySQL(t *testing.T) {
-	testLoader(
-		t,
-		"mysql",
-		os.Getenv("MYSQL_CONN_STRING"),
-		"testdata/schema/mysql.sql",
-	)
+	db := openDB(t, "mysql", os.Getenv("MYSQL_CONN_STRING"))
+	loadSchemaInOneQuery(t, db, "testdata/schema/mysql.sql")
+	testLoader(t, db, "mysql")
 }

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -1,4 +1,4 @@
-// +build postgresql
+//go:build postgresql
 
 package testfixtures
 
@@ -11,36 +11,28 @@ import (
 )
 
 func TestPostgreSQL(t *testing.T) {
-	for _, dialect := range []string{"postgres", "pgx"} {
-		testLoader(
-			t,
-			dialect,
-			os.Getenv("PG_CONN_STRING"),
-			"testdata/schema/postgresql.sql",
-		)
-	}
+	testPostgreSQL(t)
 }
 
 func TestPostgreSQLWithAlterConstraint(t *testing.T) {
-	for _, dialect := range []string{"postgres", "pgx"} {
-		testLoader(
-			t,
-			dialect,
-			os.Getenv("PG_CONN_STRING"),
-			"testdata/schema/postgresql.sql",
-			UseAlterConstraint(),
-		)
-	}
+	testPostgreSQL(t, UseAlterConstraint())
 }
 
 func TestPostgreSQLWithDropConstraint(t *testing.T) {
+	testPostgreSQL(t, UseDropConstraint())
+}
+
+func testPostgreSQL(t *testing.T, additionalOptions ...func(*Loader) error) {
+	t.Helper()
 	for _, dialect := range []string{"postgres", "pgx"} {
+		db := openDB(t, dialect, os.Getenv("PG_CONN_STRING"))
+		loadSchemaInOneQuery(t, db, "testdata/schema/postgresql.sql")
 		testLoader(
 			t,
+			db,
 			dialect,
-			os.Getenv("PG_CONN_STRING"),
-			"testdata/schema/postgresql.sql",
-			UseDropConstraint(),
+			additionalOptions...,
 		)
 	}
+
 }

--- a/spanner.go
+++ b/spanner.go
@@ -84,12 +84,6 @@ func (h *spanner) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction) (
 	return h.dropAndRecreateConstraints(db, loadFn)
 }
 
-// splitter is a batchSplitter interface implementation. We need it for
-// spanner because spanner doesn't support multi-statements.
-func (*spanner) splitter() []byte {
-	return []byte(";\n")
-}
-
 func (h *spanner) cleanTableQuery(tableName string) string {
 	if h.cleanTableFn == nil {
 		return h.baseHelper.cleanTableQuery(tableName)

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -18,13 +18,9 @@ import (
 func TestSpanner(t *testing.T) {
 	prepareSpannerDB(t)
 
-	testLoader(
-		t,
-		"spanner",
-		os.Getenv("SPANNER_CONN_STRING"),
-		"testdata/schema/spanner.sql",
-		DangerousSkipTestDatabaseCheck(),
-	)
+	db := openDB(t, "spanner", os.Getenv("SPANNER_CONN_STRING"))
+	loadSchemaInBatchesBySplitter(t, db, "testdata/schema/spanner.sql", []byte(";\n"))
+	testLoader(t, db, "spanner", DangerousSkipTestDatabaseCheck())
 }
 
 func prepareSpannerDB(t *testing.T) {

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -1,4 +1,4 @@
-// +build sqlite
+//go:build sqlite
 
 package testfixtures
 
@@ -10,10 +10,7 @@ import (
 )
 
 func TestSQLite(t *testing.T) {
-	testLoader(
-		t,
-		"sqlite3",
-		os.Getenv("SQLITE_CONN_STRING"),
-		"testdata/schema/sqlite.sql",
-	)
+	db := openDB(t, "sqlite3", os.Getenv("SQLITE_CONN_STRING"))
+	loadSchemaInOneQuery(t, db, "testdata/schema/sqlite.sql")
+	testLoader(t, db, "sqlite3")
 }

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -143,11 +143,3 @@ func (h *sqlserver) disableReferentialIntegrity(db *sql.DB, loadFn loadFunction)
 
 	return tx.Commit()
 }
-
-// splitter is a batchSplitter interface implementation. We need it for
-// SQL Server because commands like a `CREATE SCHEMA...` and a `CREATE TABLE...`
-// could not be executed in the same batch.
-// See https://docs.microsoft.com/en-us/previous-versions/sql/sql-server-2008-r2/ms175502(v=sql.105)#rules-for-using-batches
-func (*sqlserver) splitter() []byte {
-	return []byte("GO\n")
-}

--- a/sqlserver_test.go
+++ b/sqlserver_test.go
@@ -1,4 +1,4 @@
-// +build sqlserver
+//go:build sqlserver
 
 package testfixtures
 
@@ -10,21 +10,21 @@ import (
 )
 
 func TestSQLServer(t *testing.T) {
-	testLoader(
-		t,
-		"sqlserver",
-		os.Getenv("SQLSERVER_CONN_STRING"),
-		"testdata/schema/sqlserver.sql",
-		DangerousSkipTestDatabaseCheck(),
-	)
+	testSQLServer(t, "sqlserver")
 }
 
 func TestDeprecatedMssql(t *testing.T) {
+	testSQLServer(t, "mssql")
+}
+
+func testSQLServer(t *testing.T, dialect string) {
+	t.Helper()
+	db := openDB(t, dialect, os.Getenv("SQLSERVER_CONN_STRING"))
+	loadSchemaInBatchesBySplitter(t, db, "testdata/schema/sqlserver.sql", []byte("GO\n"))
 	testLoader(
 		t,
-		"mssql",
-		os.Getenv("SQLSERVER_CONN_STRING"),
-		"testdata/schema/sqlserver.sql",
+		db,
+		dialect,
 		DangerousSkipTestDatabaseCheck(),
 	)
 }


### PR DESCRIPTION
refactor tests, so private interfaces are not used:
* split batches in tests
* remove batchSplitter interface, which is not used after refactor
* replace quoteKeyword with simple substitution. it is not needed as
  table names in tests are not problematic

I need this for a lib/tests module split