### PR TITLE
feat(mysql): make multistatements parameter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,9 +399,6 @@ Tested using the [github.com/lib/pq](https://github.com/lib/pq) and
 
 ### MySQL / MariaDB
 
-Just make sure the connection string have
-[the multistatement parameter](https://github.com/go-sql-driver/mysql#multistatements)
-set to true, and use:
 
 ```go
 testfixtures.New(
@@ -411,6 +408,20 @@ testfixtures.New(
 ```
 
 Tested using the [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) driver.
+
+#### Multistatements parameter
+
+You can use [the multistatement parameter](https://github.com/go-sql-driver/mysql#multistatements) in the connection
+string to execute some of the setup statements in one query (instead of one query per statement) for a faster execution.
+
+
+```go
+testfixtures.New(
+        ...
+        testfixtures.Dialect("mysql"), // or "mariadb"
+        testfixtures.AllowMultipleStatementsInOneQuery(),
+)
+```
 
 ### SQLite
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       PGPASSWORD: postgres
       PG_CONN_STRING: host=postgresql user=postgres dbname=testfixtures_test port=5432 sslmode=disable
-      MYSQL_CONN_STRING: root:mariadb@tcp(mariadb)/testfixtures_test?multiStatements=true
+      MYSQL_CONN_STRING: root:mariadb@tcp(mariadb)/testfixtures_test
       SQLITE_CONN_STRING: testfixtures_test.sqlite3
       SQLSERVER_CONN_STRING: server=sqlserver;database=master;user id=sa;password=SQL@1server;encrypt=disable
       CRDB_CONN_STRING: host=cockroachdb user=root dbname=defaultdb port=26257 sslmode=disable

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -11,6 +11,12 @@ import (
 
 func TestMySQL(t *testing.T) {
 	db := openDB(t, "mysql", os.Getenv("MYSQL_CONN_STRING"))
-	loadSchemaInOneQuery(t, db, "testdata/schema/mysql.sql")
+	loadSchemaInBatchesBySplitter(t, db, "testdata/schema/mysql.sql", []byte(";\n"))
 	testLoader(t, db, "mysql")
+}
+
+func TestMySQLWithMultipleStatementsSupport(t *testing.T) {
+	db := openDB(t, "mysql", os.Getenv("MYSQL_CONN_STRING")+"?multiStatements=true")
+	loadSchemaInOneQuery(t, db, "testdata/schema/mysql.sql")
+	testLoader(t, db, "mysql", AllowMultipleStatementsInOneQuery())
 }

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -194,6 +194,23 @@ func SkipResetSequences() func(*Loader) error {
 	}
 }
 
+// AllowMultipleStatementsInOneQuery is a performance tweak for running some setup statements in one query for better performance.
+//
+// Your database and connection must be configured to support it: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#multistatements
+//
+// Only valid for MySQL as it is not enabled by default.
+func AllowMultipleStatementsInOneQuery() func(*Loader) error {
+	return func(l *Loader) error {
+		switch helper := l.helper.(type) {
+		case *mySQL:
+			helper.allowMultipleStatementsInOneQuery = true
+		default:
+			return fmt.Errorf("testfixtures: AllowMultipleStatementsInOneQuery is valid for MySQL database")
+		}
+		return nil
+	}
+}
+
 // ResetSequencesTo sets the value the sequences will be reset to.
 //
 // Defaults to 10000.


### PR DESCRIPTION
The #208 PR introduced an optimisation, which requires the `multiStatements=true` parameter in connection string to work properly

It looks like that the requirement for that parameter (which is stated in `README.md`) was not honored by users (e.g #240), so I want to keep the old behavior for convenience

This commit:
* remove mention about parameter requirement from `README.md`
* revert default to `one query per one statement`
* allows to keep `one query per multiple statements` logic with a `testfixtures.AllowMultipleStatementsInOneQuery` flag
* some tests for both use cases