### PR TITLE
chore: remove spanner underscore import

### DIFF
--- a/spanner.go
+++ b/spanner.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-
-	_ "github.com/googleapis/go-sql-spanner"
 )
 
 type spanner struct {

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -13,6 +13,8 @@ import (
 	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
+
+	_ "github.com/googleapis/go-sql-spanner"
 )
 
 func TestSpanner(t *testing.T) {


### PR DESCRIPTION
rationale: clients open `*db.SQL` on it own, so it is not in a scope of library to import particular db driver