### PR TITLE
feat: support quoted columns in postgresql

### DIFF
--- a/postgresql.go
+++ b/postgresql.go
@@ -410,6 +410,11 @@ func (h *postgreSQL) getChecksum(q queryable, tableName string) (string, error) 
 }
 
 func (*postgreSQL) quoteKeyword(s string) string {
+	isQuotedColumn := s[0] == '"' && s[len(s)-1] == '"'
+	if isQuotedColumn {
+		return s
+	}
+
 	parts := strings.Split(s, ".")
 	for i, p := range parts {
 		parts[i] = fmt.Sprintf(`"%s"`, p)

--- a/postgresql.go
+++ b/postgresql.go
@@ -410,7 +410,7 @@ func (h *postgreSQL) getChecksum(q queryable, tableName string) (string, error) 
 }
 
 func (*postgreSQL) quoteKeyword(s string) string {
-	isQuotedColumn := s[0] == '"' && s[len(s)-1] == '"'
+	isQuotedColumn := strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`)
 	if isQuotedColumn {
 		return s
 	}

--- a/testfixtures_test.go
+++ b/testfixtures_test.go
@@ -37,6 +37,7 @@ func TestQuoteKeyword(t *testing.T) {
 		expected string
 	}{
 		{&postgreSQL{}, `posts_tags`, `"posts_tags"`},
+		{&postgreSQL{}, `"posts.tags"`, `"posts.tags"`},
 		{&postgreSQL{}, `test_schema.posts_tags`, `"test_schema"."posts_tags"`},
 		{&sqlserver{}, `posts_tags`, `[posts_tags]`},
 		{&sqlserver{}, `test_schema.posts_tags`, `[test_schema].[posts_tags]`},


### PR DESCRIPTION
Implements #280 
It's a naming pattern used to persist value objects as part of an entity model.