### PR TITLE
Spanner: support foreign keys constraint on composite primary keys

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -3,6 +3,8 @@ package testfixtures
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 type clickhouse struct {
@@ -25,13 +27,13 @@ func (*clickhouse) paramType() int {
 	return paramTypeDollar
 }
 
-func (*clickhouse) databaseName(q queryable) (string, error) {
+func (*clickhouse) databaseName(q shared.Queryable) (string, error) {
 	var dbName string
 	err := q.QueryRow("SELECT DATABASE()").Scan(&dbName)
 	return dbName, err
 }
 
-func (h *clickhouse) tableNames(q queryable) ([]string, error) {
+func (h *clickhouse) tableNames(q shared.Queryable) ([]string, error) {
 	query := `
 		SELECT name
 		FROM system.tables

--- a/dbtests/common_test.go
+++ b/dbtests/common_test.go
@@ -173,6 +173,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures/posts_tags.yml",
 					"testdata/fixtures/users.yml",
 					"testdata/fixtures/assets.yml",
+					"testdata/fixtures/accounts.yml",
+					"testdata/fixtures/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -207,6 +209,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures/posts_tags.yml",
 					"testdata/fixtures/users.yml",
 					"testdata/fixtures/assets.yml",
+					"testdata/fixtures/accounts.yml",
+					"testdata/fixtures/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -238,6 +242,7 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures_multi_tables/users.yml",
 					"testdata/fixtures_multi_tables/posts_tags.yml",
 					"testdata/fixtures_multi_tables/assets.yml",
+					"testdata/fixtures_multi_tables/accounts_transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -270,6 +275,7 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures_multi_tables/users.yml",
 					"testdata/fixtures_multi_tables/posts_tags.yml",
 					"testdata/fixtures_multi_tables/assets.yml",
+					"testdata/fixtures_multi_tables/accounts_transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -299,6 +305,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 				testfixtures.Files(
 					"testdata/fixtures/tags.yml",
 					"testdata/fixtures/users.yml",
+					"testdata/fixtures/accounts.yml",
+					"testdata/fixtures/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -329,6 +337,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 				testfixtures.Files(
 					"testdata/fixtures/tags.yml",
 					"testdata/fixtures/users.yml",
+					"testdata/fixtures/accounts.yml",
+					"testdata/fixtures/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -358,6 +368,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures_dirs/fixtures1",
 					"testdata/fixtures_dirs/fixtures2/tags.yml",
 					"testdata/fixtures_dirs/fixtures2/users.yml",
+					"testdata/fixtures_dirs/fixtures2/accounts.yml",
+					"testdata/fixtures_dirs/fixtures2/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -388,6 +400,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures_dirs/fixtures1",
 					"testdata/fixtures_dirs/fixtures2/tags.yml",
 					"testdata/fixtures_dirs/fixtures2/users.yml",
+					"testdata/fixtures_dirs/fixtures2/accounts.yml",
+					"testdata/fixtures_dirs/fixtures2/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -420,6 +434,8 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 					"testdata/fixtures/posts_tags.yml",
 					"testdata/fixtures/users.yml",
 					"testdata/fixtures/assets.yml",
+					"testdata/fixtures/accounts.yml",
+					"testdata/fixtures/transactions.yml",
 				),
 			},
 			additionalOptions...,
@@ -532,6 +548,8 @@ func assertFixturesLoaded(t *testing.T, db *sql.DB) { //nolint
 	assertCount(t, db, "posts_tags", 6)
 	assertCount(t, db, "users", 2)
 	assertCount(t, db, "assets", 1)
+	assertCount(t, db, "accounts", 2)
+	assertCount(t, db, "transactions", 4)
 }
 
 func assertCount(t *testing.T, db *sql.DB, table string, expectedCount int) { //nolint

--- a/dbtests/spanner_test.go
+++ b/dbtests/spanner_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -14,15 +15,57 @@ import (
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
 	"cloud.google.com/go/spanner/admin/instance/apiv1/instancepb"
 	"github.com/go-testfixtures/testfixtures/v3"
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 	_ "github.com/googleapis/go-sql-spanner"
 )
 
 func TestSpanner(t *testing.T) {
 	prepareSpannerDB(t)
 
-	db := openDB(t, "spanner", os.Getenv("SPANNER_CONN_STRING"))
+	dialect := "spanner"
+	db := openDB(t, dialect, os.Getenv("SPANNER_CONN_STRING"))
 	loadSchemaInBatchesBySplitter(t, db, "testdata/schema/spanner.sql", []byte(";\n"))
-	testLoader(t, db, "spanner", testfixtures.DangerousSkipTestDatabaseCheck())
+	additionalOptions := []func(*testfixtures.Loader) error{testfixtures.DangerousSkipTestDatabaseCheck()}
+	testLoader(t, db, dialect, additionalOptions...)
+
+	t.Run("SpannerConstraints", func(t *testing.T) {
+		options := append(
+			[]func(*testfixtures.Loader) error{
+				testfixtures.Database(db),
+				testfixtures.Dialect(dialect),
+				testfixtures.Template(),
+				testfixtures.TemplateData(map[string]interface{}{
+					"PostIds": []int{1, 2},
+					"TagIds":  []int{1, 2, 3},
+				}),
+				testfixtures.Directory("testdata/fixtures"),
+				testfixtures.SkipTableChecksumComputation(),
+			},
+			additionalOptions...,
+		)
+		l, err := testfixtures.New(options...)
+		if err != nil {
+			t.Errorf("failed to create Loader: %v", err)
+			return
+		}
+
+		constraintsBefore, _ := shared.GetConstraints(db)
+
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+
+		constraintsAfter, _ := shared.GetConstraints(db)
+
+		assertSpannerConstraints(t, constraintsBefore, constraintsAfter)
+
+		// Call load again to test against a database with existing data.
+		if err := l.Load(); err != nil {
+			t.Errorf("cannot load fixtures: %v", err)
+		}
+
+		assertFixturesLoaded(t, db)
+	})
 }
 
 func prepareSpannerDB(t *testing.T) {
@@ -87,4 +130,30 @@ func createSampleDB(projectId, instanceId, databaseId string, statements ...stri
 		return fmt.Errorf("waiting for database creation to finish failed: %v", err)
 	}
 	return nil
+}
+
+//nolint:unused
+func assertSpannerConstraints(t *testing.T, constraintsBefore, constraintsAfter map[string][]shared.SpannerConstraint) {
+	if len(constraintsBefore) != len(constraintsAfter) {
+		t.Errorf("constraints before and after should have the same length")
+	}
+
+	for key, cBefore := range constraintsBefore {
+		cAfter := constraintsAfter[key]
+		if len(cBefore) != len(cAfter) {
+			t.Errorf("constraints before and after should have the same length")
+		}
+		for _, cBefore := range cBefore {
+			found := false
+			for _, cAfter := range cAfter {
+				if reflect.DeepEqual(cBefore, cAfter) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("constraint %s not found in constraintsAfter", cBefore.ConstraintName)
+			}
+		}
+	}
 }

--- a/dbtests/testdata/fixtures/accounts.yml
+++ b/dbtests/testdata/fixtures/accounts.yml
@@ -1,0 +1,13 @@
+- user_id: 1
+  id: 1
+  currency: "USD"
+  balance: 100000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+- user_id: 1
+  id: 2
+  currency: "EUR" 
+  balance: 50000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"

--- a/dbtests/testdata/fixtures/transactions.yml
+++ b/dbtests/testdata/fixtures/transactions.yml
@@ -1,0 +1,31 @@
+- id: 1
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 5000
+  created_at: "2024-01-01 10:00:00"
+  updated_at: "2024-01-01 10:00:00"
+
+- id: 2
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 2500
+  created_at: "2024-01-01 14:30:00"
+  updated_at: "2024-01-01 14:30:00"
+
+- id: 3
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 7500
+  created_at: "2024-01-02 09:15:00"
+  updated_at: "2024-01-02 09:15:00"
+
+- id: 4
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 10000
+  created_at: "2024-01-03 16:45:00"
+  updated_at: "2024-01-03 16:45:00"

--- a/dbtests/testdata/fixtures_dirs/fixtures2/accounts.yml
+++ b/dbtests/testdata/fixtures_dirs/fixtures2/accounts.yml
@@ -1,0 +1,13 @@
+- user_id: 1
+  id: 1
+  currency: "USD"
+  balance: 100000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+- user_id: 1
+  id: 2
+  currency: "EUR" 
+  balance: 50000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"

--- a/dbtests/testdata/fixtures_dirs/fixtures2/transactions.yml
+++ b/dbtests/testdata/fixtures_dirs/fixtures2/transactions.yml
@@ -1,0 +1,31 @@
+- id: 1
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 5000
+  created_at: "2024-01-01 10:00:00"
+  updated_at: "2024-01-01 10:00:00"
+
+- id: 2
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 2500
+  created_at: "2024-01-01 14:30:00"
+  updated_at: "2024-01-01 14:30:00"
+
+- id: 3
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 7500
+  created_at: "2024-01-02 09:15:00"
+  updated_at: "2024-01-02 09:15:00"
+
+- id: 4
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 10000
+  created_at: "2024-01-03 16:45:00"
+  updated_at: "2024-01-03 16:45:00"

--- a/dbtests/testdata/fixtures_multi_tables/accounts_transactions.yml
+++ b/dbtests/testdata/fixtures_multi_tables/accounts_transactions.yml
@@ -1,0 +1,47 @@
+accounts:
+- user_id: 1
+  id: 1
+  currency: "USD"
+  balance: 100000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+- user_id: 1
+  id: 2
+  currency: "EUR" 
+  balance: 50000
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+transactions:
+- id: 1
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 5000
+  created_at: "2024-01-01 10:00:00"
+  updated_at: "2024-01-01 10:00:00"
+
+- id: 2
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 2500
+  created_at: "2024-01-01 14:30:00"
+  updated_at: "2024-01-01 14:30:00"
+
+- id: 3
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 7500
+  created_at: "2024-01-02 09:15:00"
+  updated_at: "2024-01-02 09:15:00"
+
+- id: 4
+  account_id: 1
+  user_id: 1
+  currency: "USD"
+  amount: 10000
+  created_at: "2024-01-03 16:45:00"
+  updated_at: "2024-01-03 16:45:00"

--- a/dbtests/testdata/schema/clickhouse.sql
+++ b/dbtests/testdata/schema/clickhouse.sql
@@ -5,6 +5,8 @@ DROP TABLE IF EXISTS posts;
 DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS assets;
+DROP TABLE IF EXISTS accounts;
+DROP TABLE IF EXISTS transactions;
 
 CREATE TABLE posts (
 	id         UInt64,
@@ -52,4 +54,23 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id   UInt64,
 	data String
+) ENGINE = MergeTree ORDER BY id;
+
+CREATE TABLE accounts (
+	id         UInt64,
+	user_id    UInt64,
+	currency   String,
+	balance    Int64,
+	created_at DateTime DEFAULT '2000-01-01 00:00:00',
+	updated_at DateTime DEFAULT '2000-01-01 00:00:00'
+) ENGINE = MergeTree ORDER BY id;
+
+CREATE TABLE transactions (
+	id         UInt64,
+	account_id UInt64,
+	user_id    UInt64,
+	currency   String,
+	amount     Int64,
+	created_at DateTime DEFAULT '2000-01-01 00:00:00',
+	updated_at DateTime DEFAULT '2000-01-01 00:00:00'
 ) ENGINE = MergeTree ORDER BY id;

--- a/dbtests/testdata/schema/cockroachdb.sql
+++ b/dbtests/testdata/schema/cockroachdb.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS votes;
 DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS posts_tags;
@@ -56,4 +58,26 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id SERIAL PRIMARY KEY NOT NULL
 	,data BYTEA NOT NULL
+);
+
+CREATE TABLE accounts (
+	id SERIAL PRIMARY KEY NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,balance INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE transactions (
+	id SERIAL PRIMARY KEY NOT NULL
+	,account_id INT NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,amount INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );

--- a/dbtests/testdata/schema/mysql.sql
+++ b/dbtests/testdata/schema/mysql.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS votes;
 DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS posts_tags;
@@ -56,4 +58,26 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id INT PRIMARY KEY AUTO_INCREMENT
 	,data BLOB NOT NULL
+);
+
+CREATE TABLE accounts (
+	id INT PRIMARY KEY
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,balance INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE transactions (
+	id INT PRIMARY KEY
+	,account_id INT NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,amount INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );

--- a/dbtests/testdata/schema/postgresql.sql
+++ b/dbtests/testdata/schema/postgresql.sql
@@ -1,3 +1,5 @@
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS votes;
 DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS posts_tags;
@@ -56,4 +58,26 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id SERIAL PRIMARY KEY NOT NULL
 	,data BYTEA NOT NULL
+);
+
+CREATE TABLE accounts (
+	id SERIAL PRIMARY KEY
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,balance INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE transactions (
+	id SERIAL PRIMARY KEY
+	,account_id INT NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,amount INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );

--- a/dbtests/testdata/schema/spanner.sql
+++ b/dbtests/testdata/schema/spanner.sql
@@ -5,6 +5,8 @@ DROP TABLE IF EXISTS posts;
 DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS assets;
+DROP TABLE IF EXISTS accounts;
+DROP TABLE IF EXISTS transactions;
 
 CREATE SEQUENCE posts_sequence OPTIONS (
   sequence_kind="bit_reversed_positive"
@@ -80,4 +82,26 @@ CREATE SEQUENCE assets_sequence OPTIONS (
 CREATE TABLE assets (
 	id    INT64 DEFAULT (GET_NEXT_SEQUENCE_VALUE(SEQUENCE assets_sequence)),
 	data  BYTES(MAX)
+) PRIMARY KEY (id);
+
+CREATE TABLE accounts (
+	id INT64,
+	user_id INT64,
+	currency STRING(3),
+	balance INT64,
+	created_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
+	updated_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
+	CONSTRAINT FK_accounts_users_id FOREIGN KEY (user_id) REFERENCES users (id)
+) PRIMARY KEY (user_id, currency);
+
+CREATE TABLE transactions (
+	id INT64,
+	account_id INT64,
+	user_id INT64,
+	currency STRING(3),
+	amount INT64,
+	created_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
+	updated_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
+	CONSTRAINT FK_transactions_account_user_id FOREIGN KEY (user_id) REFERENCES users (id),
+	CONSTRAINT FK_transactions_account_user_id_currency FOREIGN KEY (user_id, currency) REFERENCES accounts (user_id, currency)
 ) PRIMARY KEY (id);

--- a/dbtests/testdata/schema/sqlite.sql
+++ b/dbtests/testdata/schema/sqlite.sql
@@ -1,5 +1,7 @@
 PRAGMA foreign_keys = ON;
 
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS votes;
 DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS posts_tags;
@@ -58,4 +60,26 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id INT PRIMARY KEY
 	,data BINARY NOT NULL
+);
+
+CREATE TABLE accounts (
+	id INT PRIMARY KEY
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,balance INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE transactions (
+	id INT PRIMARY KEY
+	,account_id INT NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,amount INT NOT NULL
+	,created_at TIMESTAMP NOT NULL
+	,updated_at TIMESTAMP NOT NULL
+	,FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );

--- a/dbtests/testdata/schema/sqlserver.sql
+++ b/dbtests/testdata/schema/sqlserver.sql
@@ -3,13 +3,16 @@ IF OBJECT_ID('non_default_schema.empty_table_without_fixtures', 'U') IS NOT NULL
 IF EXISTS(SELECT 1 FROM sys.schemas WHERE name = 'non_default_schema')
 	DROP SCHEMA non_default_schema;
 
+
+IF OBJECT_ID('transactions', 'U') IS NOT NULL DROP TABLE transactions;
+IF OBJECT_ID('accounts', 'U') IS NOT NULL DROP TABLE accounts;
 IF OBJECT_ID('votes', 'U') IS NOT NULL DROP TABLE votes;
 IF OBJECT_ID('comments', 'U') IS NOT NULL DROP TABLE comments;
 IF OBJECT_ID('posts_tags', 'U') IS NOT NULL DROP TABLE posts_tags;
 IF OBJECT_ID('posts', 'U') IS NOT NULL DROP TABLE posts;
 IF OBJECT_ID('tags', 'U') IS NOT NULL DROP TABLE tags;
-IF OBJECT_ID('users', 'U') IS NOT NULL DROP TABLE users;
 IF OBJECT_ID('assets', 'U') IS NOT NULL DROP TABLE assets;
+IF OBJECT_ID('users', 'U') IS NOT NULL DROP TABLE users;
 
 CREATE TABLE posts (
 	id INT IDENTITY PRIMARY KEY
@@ -70,4 +73,26 @@ CREATE TABLE users (
 CREATE TABLE assets (
 	id INT IDENTITY PRIMARY KEY NOT NULL
 	,data VARBINARY(MAX) NOT NULL
+);
+
+CREATE TABLE accounts (
+	id INT IDENTITY PRIMARY KEY NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,balance INT NOT NULL
+	,created_at DATETIME NOT NULL
+	,updated_at DATETIME NOT NULL
+	,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE TABLE transactions (
+	id INT IDENTITY PRIMARY KEY NOT NULL
+	,account_id INT NOT NULL
+	,user_id INT NOT NULL
+	,currency VARCHAR(3) NOT NULL
+	,amount INT NOT NULL
+	,created_at DATETIME NOT NULL
+	,updated_at DATETIME NOT NULL
+	,FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+	,FOREIGN KEY (user_id) REFERENCES users (id)
 );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: '3'
 services:
   testfixtures:
     image: testfixtures
+    volumes:
+      - .:/app
+    working_dir: /app
     depends_on:
       - postgresql
       - mariadb
@@ -36,16 +39,18 @@ services:
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest
+    platform: linux/amd64
     environment:
       ACCEPT_EULA: 'Y'
       SA_PASSWORD: SQL@1server
 
   cockroachdb:
-    image: cockroachdb/cockroach:v20.1.3
+    image: cockroachdb/cockroach:v20.1.3 
+    platform: linux/amd64
     command: start-single-node --store /cockroach-data --insecure --advertise-host cockroachdb
 
   clickhouse:
-    image: yandex/clickhouse-server:22-alpine
+    image: "clickhouse/clickhouse-server:latest-alpine"
     ports:
       - 9010:9000
       - 8133:8123

--- a/helper.go
+++ b/helper.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 const (
@@ -18,20 +20,14 @@ type helper interface {
 	init(*sql.DB) error
 	disableReferentialIntegrity(*sql.DB, loadFunction) error
 	paramType() int
-	databaseName(queryable) (string, error)
-	tableNames(queryable) ([]string, error)
-	isTableModified(queryable, string) (bool, error)
-	computeTablesChecksum(queryable) error
+	databaseName(shared.Queryable) (string, error)
+	tableNames(shared.Queryable) ([]string, error)
+	isTableModified(shared.Queryable, string) (bool, error)
+	computeTablesChecksum(shared.Queryable) error
 	quoteKeyword(string) string
 	whileInsertOnTable(*sql.Tx, string, func() error) error
 	cleanTableQuery(string) string
-	buildInsertSQL(q queryable, tableName string, columns, values []string) (string, error)
-}
-
-type queryable interface {
-	Exec(string, ...interface{}) (sql.Result, error)
-	Query(string, ...interface{}) (*sql.Rows, error)
-	QueryRow(string, ...interface{}) *sql.Row
+	buildInsertSQL(q shared.Queryable, tableName string, columns, values []string) (string, error)
 }
 
 var (
@@ -57,11 +53,11 @@ func (baseHelper) whileInsertOnTable(_ *sql.Tx, _ string, fn func() error) error
 	return fn()
 }
 
-func (baseHelper) isTableModified(_ queryable, _ string) (bool, error) {
+func (baseHelper) isTableModified(_ shared.Queryable, _ string) (bool, error) {
 	return true, nil
 }
 
-func (baseHelper) computeTablesChecksum(_ queryable) error {
+func (baseHelper) computeTablesChecksum(_ shared.Queryable) error {
 	return nil
 }
 
@@ -69,7 +65,7 @@ func (baseHelper) cleanTableQuery(tableName string) string {
 	return fmt.Sprintf("DELETE FROM %s", tableName)
 }
 
-func (h baseHelper) buildInsertSQL(_ queryable, tableName string, columns, values []string) (string, error) {
+func (h baseHelper) buildInsertSQL(_ shared.Queryable, tableName string, columns, values []string) (string, error) {
 	return fmt.Sprintf(
 		"INSERT INTO %s (%s) VALUES (%s)",
 		tableName,

--- a/mocks_for_test.go
+++ b/mocks_for_test.go
@@ -2,6 +2,8 @@ package testfixtures
 
 import (
 	"database/sql"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 type MockHelper struct {
@@ -17,13 +19,13 @@ func (*MockHelper) disableReferentialIntegrity(*sql.DB, loadFunction) error {
 func (*MockHelper) paramType() int {
 	return 0
 }
-func (*MockHelper) tableNames(queryable) ([]string, error) {
+func (*MockHelper) tableNames(shared.Queryable) ([]string, error) {
 	return nil, nil
 }
-func (*MockHelper) isTableModified(queryable, string) (bool, error) {
+func (*MockHelper) isTableModified(shared.Queryable, string) (bool, error) {
 	return false, nil
 }
-func (*MockHelper) computeTablesChecksum(queryable) error {
+func (*MockHelper) computeTablesChecksum(shared.Queryable) error {
 	return nil
 }
 func (*MockHelper) quoteKeyword(string) string {
@@ -32,7 +34,7 @@ func (*MockHelper) quoteKeyword(string) string {
 func (*MockHelper) whileInsertOnTable(*sql.Tx, string, func() error) error {
 	return nil
 }
-func (h *MockHelper) databaseName(queryable) (string, error) {
+func (h *MockHelper) databaseName(shared.Queryable) (string, error) {
 	return h.dbName, nil
 }
 
@@ -40,7 +42,7 @@ func (h *MockHelper) cleanTableQuery(string) string {
 	return ""
 }
 
-func (h *MockHelper) buildInsertSQL(queryable, string, []string, []string) (string, error) {
+func (h *MockHelper) buildInsertSQL(shared.Queryable, string, []string, []string) (string, error) {
 	return "", nil
 }
 

--- a/mysql.go
+++ b/mysql.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 type mySQL struct {
@@ -35,13 +37,13 @@ func (*mySQL) quoteKeyword(str string) string {
 	return fmt.Sprintf("`%s`", str)
 }
 
-func (*mySQL) databaseName(q queryable) (string, error) {
+func (*mySQL) databaseName(q shared.Queryable) (string, error) {
 	var dbName string
 	err := q.QueryRow("SELECT DATABASE()").Scan(&dbName)
 	return dbName, err
 }
 
-func (h *mySQL) tableNames(q queryable) ([]string, error) {
+func (h *mySQL) tableNames(q shared.Queryable) ([]string, error) {
 	const query = `
 		SELECT table_name
 		FROM information_schema.tables
@@ -146,7 +148,7 @@ func (h *mySQL) makeResetSequenceQuery(tableName string, resetSequencesTo int64)
 	return fmt.Sprintf("ALTER TABLE %s AUTO_INCREMENT = %d;", h.quoteKeyword(tableName), resetSequencesTo)
 }
 
-func (h *mySQL) isTableModified(q queryable, tableName string) (bool, error) {
+func (h *mySQL) isTableModified(q shared.Queryable, tableName string) (bool, error) {
 	oldChecksum, found := h.tablesChecksum[tableName]
 	if !found {
 		return true, nil
@@ -159,7 +161,7 @@ func (h *mySQL) isTableModified(q queryable, tableName string) (bool, error) {
 	return checksum != oldChecksum, nil
 }
 
-func (h *mySQL) computeTablesChecksum(q queryable) error {
+func (h *mySQL) computeTablesChecksum(q shared.Queryable) error {
 	if h.tablesChecksum != nil {
 		return nil
 	}
@@ -175,7 +177,7 @@ func (h *mySQL) computeTablesChecksum(q queryable) error {
 	return nil
 }
 
-func (h *mySQL) getChecksum(q queryable, tableName string) (int64, error) {
+func (h *mySQL) getChecksum(q shared.Queryable, tableName string) (int64, error) {
 	query := fmt.Sprintf("CHECKSUM TABLE %s", h.quoteKeyword(tableName))
 	var (
 		table    string

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -1,0 +1,79 @@
+// Shared code between implementation and tests. DO NOT IMPORT IT as the contract may change between versions
+package shared
+
+import (
+	"database/sql"
+)
+
+type Queryable interface {
+	Exec(string, ...interface{}) (sql.Result, error)
+	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) *sql.Row
+}
+
+type SpannerConstraint struct {
+	TableName        string
+	ConstraintName   string
+	ColumnName       string
+	Position         int
+	ReferencedTable  string
+	ReferencedColumn string
+}
+
+func GetConstraints(q Queryable) (map[string][]SpannerConstraint, error) {
+	var constraints = make(map[string][]SpannerConstraint)
+
+	rows, err := q.Query(SpannerConstraintsQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	for rows.Next() {
+		var constraint SpannerConstraint
+		if err = rows.Scan(
+			&constraint.TableName,
+			&constraint.ConstraintName,
+			&constraint.ColumnName,
+			&constraint.Position,
+			&constraint.ReferencedTable,
+			&constraint.ReferencedColumn,
+		); err != nil {
+			return nil, err
+		}
+
+		if constraints[constraint.ConstraintName] == nil {
+			constraints[constraint.ConstraintName] = []SpannerConstraint{}
+		}
+		constraints[constraint.ConstraintName] = append(constraints[constraint.ConstraintName], constraint)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return constraints, nil
+}
+
+const SpannerConstraintsQuery = `
+	SELECT 
+			tc.TABLE_NAME AS table_name,
+			tc.CONSTRAINT_NAME AS constraint_name,
+			kcu.COLUMN_NAME AS column_name,
+			kcu.ORDINAL_POSITION AS position,
+			kcu2.TABLE_NAME AS referenced_table,
+			kcu2.COLUMN_NAME AS referenced_column
+		FROM information_schema.TABLE_CONSTRAINTS tc
+		JOIN information_schema.KEY_COLUMN_USAGE kcu
+			ON tc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
+			AND tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+		JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+			ON tc.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+			AND tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+		JOIN information_schema.KEY_COLUMN_USAGE kcu2
+			ON rc.UNIQUE_CONSTRAINT_SCHEMA = kcu2.CONSTRAINT_SCHEMA
+			AND rc.UNIQUE_CONSTRAINT_NAME = kcu2.CONSTRAINT_NAME
+			AND kcu.ORDINAL_POSITION = kcu2.ORDINAL_POSITION
+		WHERE tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
+		ORDER BY tc.TABLE_NAME, tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
+`

--- a/sqlite.go
+++ b/sqlite.go
@@ -3,6 +3,8 @@ package testfixtures
 import (
 	"database/sql"
 	"path/filepath"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 type sqlite struct {
@@ -13,7 +15,7 @@ func (*sqlite) paramType() int {
 	return paramTypeQuestion
 }
 
-func (*sqlite) databaseName(q queryable) (string, error) {
+func (*sqlite) databaseName(q shared.Queryable) (string, error) {
 	var seq int
 	var main, dbName string
 	err := q.QueryRow("PRAGMA database_list").Scan(&seq, &main, &dbName)
@@ -24,7 +26,7 @@ func (*sqlite) databaseName(q queryable) (string, error) {
 	return dbName, nil
 }
 
-func (*sqlite) tableNames(q queryable) ([]string, error) {
+func (*sqlite) tableNames(q shared.Queryable) ([]string, error) {
 	query := `
 		SELECT name
 		FROM sqlite_master

--- a/sqlserver.go
+++ b/sqlserver.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/go-testfixtures/testfixtures/v3/shared"
 )
 
 type sqlserver struct {
@@ -49,13 +51,13 @@ func (*sqlserver) quoteKeyword(s string) string {
 	return strings.Join(parts, ".")
 }
 
-func (*sqlserver) databaseName(q queryable) (string, error) {
+func (*sqlserver) databaseName(q shared.Queryable) (string, error) {
 	var dbName string
 	err := q.QueryRow("SELECT DB_NAME()").Scan(&dbName)
 	return dbName, err
 }
 
-func (*sqlserver) tableNames(q queryable) ([]string, error) {
+func (*sqlserver) tableNames(q shared.Queryable) ([]string, error) {
 	rows, err := q.Query("SELECT table_schema + '.' + table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_name <> 'spt_values' AND table_type = 'BASE TABLE'")
 	if err != nil {
 		return nil, err
@@ -78,7 +80,7 @@ func (*sqlserver) tableNames(q queryable) ([]string, error) {
 	return tables, nil
 }
 
-func (h *sqlserver) tableHasIdentityColumn(q queryable, tableName string) (bool, error) {
+func (h *sqlserver) tableHasIdentityColumn(q shared.Queryable, tableName string) (bool, error) {
 	sql := fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM sys.identity_columns


### PR DESCRIPTION
This PR adds support ( fixes a bug or incomplete implementation for spanner ) for foreign key constraints on composite primary keys for google cloud spanner. 

Given this example schema: 

```sql
CREATE TABLE users (
	id          INT64 DEFAULT (GET_NEXT_SEQUENCE_VALUE(SEQUENCE users_sequence)),
	attributes  STRING(MAX)
) PRIMARY KEY (id);

CREATE TABLE accounts (
	id INT64,
	user_id INT64,
	currency STRING(3),
	balance INT64,
	created_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
	updated_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
	CONSTRAINT FK_accounts_users_id FOREIGN KEY (user_id) REFERENCES users (id)
) PRIMARY KEY (user_id, currency);

CREATE TABLE transactions (
	id INT64,
	account_id INT64,
	user_id INT64,
	currency STRING(3),
	amount INT64,
	created_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
	updated_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
	CONSTRAINT FK_transactions_account_user_id FOREIGN KEY (user_id) REFERENCES users (id),
	CONSTRAINT FK_transactions_account_user_id_currency FOREIGN KEY (user_id, currency) REFERENCES accounts (user_id, currency)
) PRIMARY KEY (id);
```

`FK_transactions_account_user_id_currency`  would not be restored correctly after the constraints are dropped and the fixtures are loaded because of the way the constraints are handled. 
