### PR TITLE
Spanner: add support for interleaved tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ testfixtures.New(
 )
 ```
 
+ **Important:** Spanner's interleaved tables require specific insertion order to satisfy parent-child dependencies. For this reason, the `Directory()` and `Paths()` methods are not supported with Spanner as they load files alphabetically, which can violate interleaved table constraints. You must use `Files()` or `FilesMultiTables()` instead, ensuring parent tables are listed before their interleaved child tables in the file order, or that they are listed in the right order in a file that contains records for more than one table as supported by `FilesMultiTables()`.
+
 ## Templating
 
 Testfixtures supports templating, but it's disabled by default. Most people

--- a/dbtests/common_test.go
+++ b/dbtests/common_test.go
@@ -68,6 +68,9 @@ func loadSchemaInBatches(t *testing.T, db *sql.DB, batches [][]byte) { //nolint:
 
 func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...func(*testfixtures.Loader) error) { //nolint:unused
 	t.Run("LoadFromDirectory", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -99,6 +102,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromDirectory with SkipTableChecksumComputation", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -131,6 +137,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromDirectory-Multiple", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -292,6 +301,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromDirectoryAndFiles", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -323,6 +335,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromDirectoryAndFilesWithFS", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -355,6 +370,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromPaths", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -386,6 +404,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromPathsWithFS", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -418,6 +439,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromPaths-OnlyFiles", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -452,6 +476,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("LoadFromPaths-OnlyDirs", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		options := append(
 			[]func(*testfixtures.Loader) error{
 				testfixtures.Database(db),
@@ -480,6 +507,9 @@ func testLoader(t *testing.T, db *sql.DB, dialect string, additionalOptions ...f
 	})
 
 	t.Run("GenerateAndLoad", func(t *testing.T) {
+		if dialect == "spanner" {
+			t.Skip("Spanner does not support loading fixtures from a directory")
+		}
 		dir, err := os.MkdirTemp(os.TempDir(), "testfixtures_test")
 		if err != nil {
 			t.Errorf("cannot create temp dir: %v", err)

--- a/dbtests/testdata/schema/spanner.sql
+++ b/dbtests/testdata/schema/spanner.sql
@@ -104,4 +104,4 @@ CREATE TABLE transactions (
 	updated_at TIMESTAMP NOT NULL DEFAULT(CURRENT_TIMESTAMP()),
 	CONSTRAINT FK_transactions_account_user_id FOREIGN KEY (user_id) REFERENCES users (id),
 	CONSTRAINT FK_transactions_account_user_id_currency FOREIGN KEY (user_id, currency) REFERENCES accounts (user_id, currency)
-) PRIMARY KEY (id);
+) PRIMARY KEY (user_id, currency, id), INTERLEAVE IN PARENT accounts ON DELETE CASCADE;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       SA_PASSWORD: SQL@1server
 
   cockroachdb:
-    image: cockroachdb/cockroach:v20.1.3 
+    image: cockroachdb/cockroach:v24.1.0 
     platform: linux/amd64
     command: start-single-node --store /cockroach-data --insecure --advertise-host cockroachdb
 

--- a/dump.go
+++ b/dump.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"unicode/utf8"
 
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // Dumper is resposible for dumping fixtures from the database into a

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/go-sql-driver/mysql v1.9.2
+	github.com/goccy/go-yaml v1.17.1
 	github.com/googleapis/go-sql-spanner v1.13.0
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/joho/godotenv v1.5.1
@@ -16,7 +17,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/sync v0.13.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -84,4 +84,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250414145226-207652e42e2e // indirect
 	google.golang.org/grpc v1.71.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -741,6 +741,8 @@ github.com/go-sql-driver/mysql v1.9.2 h1:4cNKDYQ1I84SXslGddlsrMhc8k4LeDVj6Ad6WRj
 github.com/go-sql-driver/mysql v1.9.2/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/postgresql.go
+++ b/postgresql.go
@@ -92,7 +92,7 @@ func (h *postgreSQL) tableNames(q shared.Queryable) ([]string, error) {
 		FROM pg_class
 		INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
 		WHERE pg_class.relkind = 'r'
-		  AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema', 'crdb_internal')
+		  AND pg_namespace.nspname NOT IN ('pg_catalog', 'information_schema', 'crdb_internal', 'pg_extension')
 		  AND pg_namespace.nspname NOT LIKE 'pg_toast%'
 		  AND pg_namespace.nspname NOT LIKE '\_timescaledb%';
 	`

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -77,3 +77,10 @@ const SpannerConstraintsQuery = `
 		WHERE tc.CONSTRAINT_TYPE = 'FOREIGN KEY'
 		ORDER BY tc.TABLE_NAME, tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
 `
+
+const ErrorMessage_NotSupportedLoadingMethod = `
+testfixtures: %s is not supported for Spanner to ensure support for INTERLEAVED tables. 
+Use Files():
+  ensure the order of the files is correct, parents loaded before children or 
+Use FilesMultiTables():
+  and order your table keys in the yaml files from parent to child`


### PR DESCRIPTION
Spanner has the concept of [_interleaved tables_](https://cloud.google.com/spanner/docs/schema-and-data-model#parent-child) which creates a parent/child relationship between one or more tables. These constraints can't be changed (afaik) without dropping the tables and recreating them. 

In order to provide a better experience for Spanner users, this PR drops support for using `testfixtures.Directory` and `testfixtures.Paths` for Spanner and directs users of Google Cloud Spanner to use either `testfixtures.Files` or `testfixtures.FilesMutiTable`. 

With `.Files` the user can list the files in the order they want them loaded. 
With `.FilesMultiTable` we now ensure that the order of the table keys is preserved.

