### PR TITLE
docs: add warning about importance of option order

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ testfixtures.New(
         TemplateDelims("{{", "}}"),
         TemplateOptions("missingkey=zero"),
         TemplateData(...),
+        ...
 )
 ```
 
@@ -524,6 +525,8 @@ The YAML file could look like this:
   text: {{$post.Text}}
 {{end}}
 ```
+
+ **Important:** `Template()` and its related options need to be placed before the `Directory()`, `Files()` or `Paths()` methods.
 
 ## Generating fixtures for an existing database
 


### PR DESCRIPTION
If you place `Template()` methods after `Directory()` method, then templating won't be applied resulting in error. This commit adds a very short warning message in readme about that behaviour.
I found out about it in following discussion: https://github.com/go-testfixtures/testfixtures/issues/60